### PR TITLE
fix(api): geocoder address path is /api/geocoder/address/{id}, not /a…

### DIFF
--- a/src/api/address.ts
+++ b/src/api/address.ts
@@ -13,10 +13,10 @@ export default {
 
     /**
      * Gets a single address from our geocoder by id.
-     * Canonical FunderMapsApi path: /api/geocoder/:id/address
-     * @param id Internal geocoder id.
+     * Canonical FunderMapsApi path: /api/geocoder/address/:id
+     * @param id Internal geocoder id (gfm-*), BAG NUMMERAANDUIDING, or BAG PAND.
      */
     getAddressById(id: string) {
-        return axios.get(`/api/geocoder/${id}/address`);
+        return axios.get(`/api/geocoder/address/${id}`);
     }
 }


### PR DESCRIPTION
…pi/geocoder/{id}/address

Wrong order shipped in the cutover commit — silently 404'd address lookups for sample-attached gfm-* IDs. Canonical TS API path matches the C# WebApi.