### PR TITLE
fix(clientapp): Tailwind v4 class migrations (broken button colors, text wrap)

### DIFF
--- a/public/resources/styles/components/panel/sidebar.css
+++ b/public/resources/styles/components/panel/sidebar.css
@@ -6,7 +6,7 @@
   }
 
   .panel {
-    @apply z-10 h-full w-full flex-shrink-0 space-y-2 bg-white/80 pt-4 backdrop-blur-md;
+    @apply z-10 h-full w-full shrink-0 space-y-2 bg-white/80 pt-4 backdrop-blur-md;
 
     > * {
       @apply px-7;

--- a/src/components/Common/Buttons/Button.vue
+++ b/src/components/Common/Buttons/Button.vue
@@ -14,9 +14,9 @@ const { link, outline, muted, danger } = defineProps({
 const btnClass = computed<string[]>(() => {
   if (link) return ['button-link']
   if (danger)
-    return ['button--solid', '!bg-red-500', 'hover:!bg-red-800', 'disabled:!bg-grey-400', 'group']
+    return ['button--solid', 'bg-red-500!', 'hover:bg-red-800!', 'disabled:bg-grey-400!', 'group']
   if (outline) return ['button--outline', 'group']
-  if (muted) return ['button--solid', '!bg-grey-700', 'hover:!bg-grey-800', 'group']
+  if (muted) return ['button--solid', 'bg-grey-700!', 'hover:bg-grey-800!', 'group']
   return ['button--solid', 'group']
 })
 </script>

--- a/src/components/Inquiry/SampleForm.vue
+++ b/src/components/Inquiry/SampleForm.vue
@@ -71,12 +71,12 @@ function onSave() {
       class="-mx-5 -mt-5 flex flex-wrap items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
     >
       <div class="min-w-0 flex-1">
-        <h3 class="heading-3 break-words">
+        <h3 class="heading-3 wrap-break-word">
           {{ formatAddress(addressStore.cache[form.address]) }}
         </h3>
         <p v-if="form.building" class="text-xs text-grey-700">Pand: {{ form.building }}</p>
       </div>
-      <div class="flex flex-shrink-0 gap-2">
+      <div class="flex shrink-0 gap-2">
         <Button label="Verwijderen" danger @click="emit('delete')" />
         <Button label="Opslaan" type="submit" :disabled="saving" @click="onSave" />
       </div>

--- a/src/components/Layout/Header.vue
+++ b/src/components/Layout/Header.vue
@@ -15,11 +15,11 @@ const navLinks = [
 
 <template>
   <header
-    class="app-header fixed inset-x-0 top-0 isolate z-50 flex h-16 items-center gap-8 bg-white/85 px-6 shadow-[0_1px_0_0_var(--color-grey-200)] backdrop-blur supports-[backdrop-filter]:bg-white/75"
+    class="app-header fixed inset-x-0 top-0 isolate z-50 flex h-16 items-center gap-8 bg-white/85 px-6 shadow-[0_1px_0_0_var(--color-grey-200)] backdrop-blur supports-backdrop-filter:bg-white/75"
   >
     <RouterLink
       :to="{ name: 'inquiry-list' }"
-      class="flex-shrink-0 outline-none"
+      class="shrink-0 outline-none"
       aria-label="FunderMaps"
     >
       <img :src="fundermapsLogo" alt="FunderMaps" class="h-7 w-auto" />

--- a/src/components/Recovery/SampleForm.vue
+++ b/src/components/Recovery/SampleForm.vue
@@ -100,12 +100,12 @@ function onSave() {
       class="-mx-5 -mt-5 flex flex-wrap items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
     >
       <div class="min-w-0 flex-1">
-        <h3 class="heading-3 break-words">
+        <h3 class="heading-3 wrap-break-word">
           {{ formatAddress(addressStore.cache[form.building]) }}
         </h3>
         <p v-if="form.building" class="text-xs text-grey-700">Pand: {{ form.building }}</p>
       </div>
-      <div class="flex flex-shrink-0 gap-2">
+      <div class="flex shrink-0 gap-2">
         <Button label="Verwijderen" danger @click="emit('delete')" />
         <Button label="Opslaan" type="submit" :disabled="saving" @click="onSave" />
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   --color-*: initial;
@@ -94,25 +94,27 @@
   --text-4xl--line-height: 1.125;
   --text-4xl--letter-spacing: -0.001em;
 
-  --shadow-hover: 0 10px 20px 0px rgb(0 0 0 / 0.1), 0 4px 4px 0px rgb(0 0 0 / 0.1);
-  --shadow-card: 0 10px 20px 0px rgb(0 0 0 / 0.1), 0 4px 4px 0px rgb(0 0 0 / 0.1);
+  --shadow-hover:
+    0 10px 20px 0px rgb(0 0 0 / 0.1), 0 4px 4px 0px rgb(0 0 0 / 0.1);
+  --shadow-card:
+    0 10px 20px 0px rgb(0 0 0 / 0.1), 0 4px 4px 0px rgb(0 0 0 / 0.1);
   --shadow-float: 0px 5px 15px 0px rgb(44 45 60 / 0.2);
 }
 
 html {
   color-scheme: light;
-  accent-color: theme(colors.green.500);
+  accent-color: var(--color-green-500);
   scroll-behavior: smooth;
   -webkit-text-size-adjust: 100%;
 }
 
 ::selection {
-  background-color: theme(colors.green.100);
-  color: theme(colors.green.800);
+  background-color: var(--color-green-100);
+  color: var(--color-green-800);
 }
 
 .button:focus-visible {
-  outline: 2px solid theme(colors.green.500);
+  outline: 2px solid var(--color-green-500);
   outline-offset: 2px;
 }
 
@@ -136,7 +138,7 @@ html {
 }
 
 .page-dashboard {
-  grid-template-rows: [header] theme(spacing.16) [main] auto;
+  grid-template-rows: [header] --spacing(16) [main] auto;
 }
 
 .card {
@@ -146,13 +148,13 @@ html {
 }
 
 tr.is-selected-row td {
-  background-color: theme(colors.green.100) !important;
+  background-color: var(--color-green-100) !important;
 }
 
 .List .bh-table-responsive tbody tr:hover td {
-  background-color: theme(colors.grey.100);
+  background-color: var(--color-grey-100);
   cursor: pointer;
 }
 .List .bh-table-responsive tbody tr.is-selected-row:hover td {
-  background-color: theme(colors.green.100) !important;
+  background-color: var(--color-green-100) !important;
 }


### PR DESCRIPTION
## Why the UI looked messed up

The Tailwind 4 upgrade (#227) bumped the deps but **not the template class names**. When `@tailwindcss/upgrade` first ran, ClientApp's CSS entry still used `@import url("tailwindcss/base.css")`, so the codemod couldn't detect Tailwind and skipped its stylesheet/template pass. That left several v3-only class syntaxes that **silently do nothing** under v4 (no build error) — hence the subtle breakage.

## Fixes

Re-ran the codemod now that `src/style.css` uses `@import "tailwindcss"`, plus one manual fix in the `public/` CSS tree (which the codemod doesn't scan):

| v3 | v4 | symptom |
|---|---|---|
| `!bg-red-500` (prefix `!`) | `bg-red-500!` (suffix) | **danger/muted buttons lost their colors** |
| `break-words` | `wrap-break-word` | long addresses stopped wrapping |
| `flex-shrink-0` | `shrink-0` | (templates + `panel/sidebar.css`) |
| `supports-[backdrop-filter]:` | `supports-backdrop-filter:` | sticky header backdrop |
| leftover `theme(...)` | `var(--…)` / `--spacing(16)` | in `style.css` |

Note: bare `rounded`/`shadow`/`backdrop-blur` are **still valid** in v4 — the codemod left them untouched, so they were never the issue.

The panels themselves (Card/Panel) share the design system with WebFront/ManagementFront and are structurally fine once these class fixes land.

## Verification
`pnpm build` green; the `bg-red-500!`, `wrap-break-word`, and `shrink-0` rules now generate in the output CSS; dev server serves `/` and `/inquiries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)