### PR TITLE
feat(auth): become an OIDC client (sign in via the auth app)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import { hasAccessToken } from '@/services/fundermaps/session'
 import { useSessionStore } from '@/stores/session'
 
 import Login from '@/views/auth/Login.vue'
+import Callback from '@/views/auth/Callback.vue'
 import Logout from '@/views/auth/Logout.vue'
 import NotFound from '@/views/auth/NotFound.vue'
 import InquiryList from '@/views/InquiryListView.vue'
@@ -20,6 +21,7 @@ import RecoveryView from '@/views/recovery/RecoveryView.vue'
 
 const routes: RouteRecordRaw[] = [
   { name: 'login', path: '/login', component: Login, meta: { layout: 'login', public: true } },
+  { name: 'auth-callback', path: '/auth/callback', component: Callback, meta: { layout: 'login', public: true } },
   { name: 'logout', path: '/logout', component: Logout, meta: { layout: 'empty' } },
 
   { path: '/', redirect: { name: 'inquiry-list' } },

--- a/src/services/oidc.ts
+++ b/src/services/oidc.ts
@@ -1,0 +1,85 @@
+/**
+ * OIDC (authorization-code + PKCE) client for the FunderMaps auth provider.
+ *
+ * ClientApp is a trusted first-party OIDC client: unauthenticated users are
+ * sent to the auth app (auth.fundermaps.com) to sign in, then returned here
+ * with a code we exchange for an access token. The token is stored as the
+ * bearer (same `access_token` slot the app already uses) — no consent screen,
+ * and no refresh token for now (the access token is re-obtained by bouncing
+ * through /authorize again, which is silent while the SSO session is alive).
+ */
+import { storeAccessToken } from './fundermaps/session'
+
+const API = (import.meta.env.VITE_FUNDERMAPS_URL || '').replace(/\/+$/, '')
+const CLIENT_ID = 'clientapp'
+const VERIFIER_KEY = 'oidc_pkce_verifier'
+const STATE_KEY = 'oidc_state'
+
+function redirectUri(): string {
+  return `${window.location.origin}/auth/callback`
+}
+
+function randomUrlSafe(byteLength: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength))
+  return base64url(bytes)
+}
+
+function base64url(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+  return base64url(new Uint8Array(digest))
+}
+
+/** Begin login: stash PKCE verifier + state, then navigate to /oauth2/authorize. */
+export async function loginRedirect(): Promise<void> {
+  const verifier = randomUrlSafe(48)
+  const state = randomUrlSafe(16)
+  sessionStorage.setItem(VERIFIER_KEY, verifier)
+  sessionStorage.setItem(STATE_KEY, state)
+
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: redirectUri(),
+    scope: 'openid email profile',
+    state,
+    code_challenge: await pkceChallenge(verifier),
+    code_challenge_method: 'S256',
+  })
+  window.location.assign(`${API}/api/auth/oauth2/authorize?${params.toString()}`)
+}
+
+/** Finish login: validate state, exchange the code for a token, store it. */
+export async function exchangeCode(code: string, state: string): Promise<void> {
+  const verifier = sessionStorage.getItem(VERIFIER_KEY)
+  const expectedState = sessionStorage.getItem(STATE_KEY)
+  if (!verifier || !state || state !== expectedState) {
+    throw new Error('Invalid OIDC state')
+  }
+
+  const res = await fetch(`${API}/api/auth/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri(),
+      client_id: CLIENT_ID,
+      code_verifier: verifier,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`Token exchange failed (${res.status})`)
+  }
+  const tokens = (await res.json()) as { access_token?: string }
+  if (!tokens.access_token) throw new Error('No access token in token response')
+
+  storeAccessToken(tokens.access_token)
+  sessionStorage.removeItem(VERIFIER_KEY)
+  sessionStorage.removeItem(STATE_KEY)
+}

--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+
+import AuthWrapper from '@/components/Layout/AuthWrapper.vue'
+import { exchangeCode } from '@/services/oidc'
+import { useSessionStore } from '@/stores/session'
+
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const sessionStore = useSessionStore()
+
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  const code = route.query.code
+  const state = route.query.state
+  if (typeof code !== 'string') {
+    error.value = t('auth.invalidCredentials')
+    return
+  }
+  try {
+    await exchangeCode(code, typeof state === 'string' ? state : '')
+    await sessionStore.authenticateFromAccessToken()
+    router.replace({ name: 'inquiry-list' })
+  } catch {
+    error.value = t('auth.invalidCredentials')
+  }
+})
+</script>
+
+<template>
+  <AuthWrapper :title="t('app.title')">
+    <p v-if="error" class="text-sm text-red-500">{{ error }}</p>
+    <p v-else class="text-sm text-grey-700">{{ t('common.loading') }}</p>
+  </AuthWrapper>
+</template>

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -1,73 +1,23 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useSessionStore } from '@/stores/session'
+
 import AuthWrapper from '@/components/Layout/AuthWrapper.vue'
+import { loginRedirect } from '@/services/oidc'
 
+// Login now lives in the dedicated auth app (auth.fundermaps.com). This route
+// is just the entry point: it kicks off the OIDC authorization-code flow and
+// hands off to the auth app. The guard routes unauthenticated users here, and
+// logout returns here too.
 const { t } = useI18n()
-const router = useRouter()
-const sessionStore = useSessionStore()
 
-const email = ref('')
-const password = ref('')
-const error = ref<string | null>(null)
-const submitting = ref(false)
-
-async function onSubmit() {
-  if (submitting.value) return
-  submitting.value = true
-  error.value = null
-  try {
-    await sessionStore.login(email.value, password.value)
-    router.push({ name: 'inquiry-list' })
-  } catch {
-    error.value = t('auth.invalidCredentials')
-  } finally {
-    submitting.value = false
-  }
-}
+onMounted(() => {
+  loginRedirect()
+})
 </script>
 
 <template>
   <AuthWrapper :title="t('app.title')">
-    <form
-      class="card w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow-card"
-      @submit.prevent="onSubmit"
-    >
-      <h2 class="text-xl text-blue-900">{{ t('auth.login') }}</h2>
-
-      <label class="block">
-        <span class="text-sm text-grey-800">{{ t('auth.email') }}</span>
-        <input
-          v-model="email"
-          type="email"
-          autocomplete="email"
-          required
-          class="mt-1 w-full rounded border border-grey-400 p-2"
-        />
-      </label>
-
-      <label class="block">
-        <span class="text-sm text-grey-800">{{ t('auth.password') }}</span>
-        <input
-          v-model="password"
-          type="password"
-          autocomplete="current-password"
-          required
-          class="mt-1 w-full rounded border border-grey-400 p-2"
-        />
-      </label>
-
-      <p v-if="error" class="text-sm text-red-500">{{ error }}</p>
-
-      <button
-        type="submit"
-        :disabled="submitting"
-        class="button w-full rounded bg-green-500 p-2 text-white disabled:opacity-50"
-      >
-        {{ t('auth.login') }}
-      </button>
-    </form>
+    <p class="text-sm text-grey-700">{{ t('common.loading') }}</p>
   </AuthWrapper>
 </template>


### PR DESCRIPTION
Part of the **Phase B** OIDC pilot — ClientApp is the first first-party app to move to SSO. Pairs with `FunderMapsAuth#feat/oidc-resume` and `FunderMapsApi#feat/oidc-auth-spa`.

Replaces the local email/password form with authorization-code + PKCE against the FunderMaps auth provider. Login happens at `auth.fundermaps.com` (no consent — trusted client); ClientApp kicks off `/authorize` and exchanges the returned code for an access token.

- `services/oidc.ts`: PKCE `loginRedirect()` + `exchangeCode()`.
- `views/auth/Login.vue`: now an OIDC-redirect shim (guard routes here; logout returns here → both flow to the auth app).
- `views/auth/Callback.vue` + `/auth/callback` (public): exchange the code, store the token, load the user, go to the inquiry list.

**Requires before deploy:** the auth-SPA + API PRs deployed, and the `clientapp` OIDC client registered in prod (Worker migration) with this app's prod `redirect_uri` = `https://<clientapp-domain>/auth/callback`.

Verified locally end-to-end against the dev API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)