### PR TITLE
fix(auth): no login-page flash before the OIDC redirect

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia'
 
 import { hasAccessToken } from '@/services/fundermaps/session'
 import { useSessionStore } from '@/stores/session'
+import { loginRedirect } from '@/services/oidc'
 
 import Login from '@/views/auth/Login.vue'
 import Callback from '@/views/auth/Callback.vue'
@@ -20,7 +21,20 @@ import RecoveryStep3 from '@/views/recovery/RecoveryStep3.vue'
 import RecoveryView from '@/views/recovery/RecoveryView.vue'
 
 const routes: RouteRecordRaw[] = [
-  { name: 'login', path: '/login', component: Login, meta: { layout: 'login', public: true } },
+  // Login lives in the auth app. Redirect to OIDC in beforeEnter — before the
+  // component renders — so no local login page flashes during the hand-off.
+  // Reached via logout (push to 'login') and direct /login hits; the global
+  // guard handles protected routes the same way.
+  {
+    name: 'login',
+    path: '/login',
+    component: Login,
+    meta: { layout: 'login', public: true },
+    beforeEnter: async () => {
+      await loginRedirect()
+      return false
+    },
+  },
   { name: 'auth-callback', path: '/auth/callback', component: Callback, meta: { layout: 'login', public: true } },
   { name: 'logout', path: '/logout', component: Logout, meta: { layout: 'empty' } },
 
@@ -66,7 +80,10 @@ router.beforeEach(async (to) => {
   if (to.meta.public) return true
 
   if (!isAuthenticated.value) {
-    return { name: 'login' }
+    // Hand off to the auth app here, before any route component renders, so the
+    // user never sees a local login page flash.
+    await loginRedirect()
+    return false
   }
 })
 

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
-import { useI18n } from 'vue-i18n'
 
-import AuthWrapper from '@/components/Layout/AuthWrapper.vue'
 import { loginRedirect } from '@/services/oidc'
 
-// Login now lives in the dedicated auth app (auth.fundermaps.com). This route
-// is just the entry point: it kicks off the OIDC authorization-code flow and
-// hands off to the auth app. The guard routes unauthenticated users here, and
-// logout returns here too.
-const { t } = useI18n()
-
+// Login lives in the auth app (auth.fundermaps.com). The router redirects to
+// the OIDC flow before this component renders (the global guard + this route's
+// beforeEnter), so this is normally never shown. The onMounted call is a
+// defensive fallback, and the template renders nothing so there is no flash of
+// a local login page during the hand-off.
 onMounted(() => {
   loginRedirect()
 })
 </script>
 
 <template>
-  <AuthWrapper :title="t('app.title')">
-    <p class="text-sm text-grey-700">{{ t('common.loading') }}</p>
-  </AuthWrapper>
+  <div />
 </template>


### PR DESCRIPTION
Follow-up to #231. Users briefly saw the old local login page before being redirected to the auth app: `Login.vue` rendered its `AuthWrapper` chrome for a frame, then its `onMounted` hook fired the redirect.

Fix: hand off to OIDC **before** any component renders.
- **Global guard** — unauthenticated → `await loginRedirect(); return false` (no longer routes to the local `login` route), so protected-route entries (the common path) redirect before mount.
- **`login` route `beforeEnter`** — same redirect, covering logout and direct `/login` hits.
- **`Login.vue`** — now renders nothing; the `onMounted` redirect remains only as a defensive fallback.

Net: the fresh-load path shows a brief blank during SPA boot (unavoidable for a static SPA) then the auth app — no flash of a local login page.

Build clean. Visual confirmation on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)