### PR TITLE
fix(auth): neutral OIDC callback screen (no login-page flash on return)

### DIFF
--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -3,7 +3,7 @@ import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
-import AuthWrapper from '@/components/Layout/AuthWrapper.vue'
+import Spinner from '@/components/Common/Spinner.vue'
 import { exchangeCode } from '@/services/oidc'
 import { useSessionStore } from '@/stores/session'
 
@@ -32,8 +32,11 @@ onMounted(async () => {
 </script>
 
 <template>
-  <AuthWrapper :title="t('app.title')">
+  <!-- Neutral loading while the code is exchanged — deliberately NOT the
+       AuthWrapper login chrome, so the hand-off back from the auth app doesn't
+       flash a login-page look before landing on the app. -->
+  <div class="grid min-h-screen place-content-center">
     <p v-if="error" class="text-sm text-red-500">{{ error }}</p>
-    <p v-else class="text-sm text-grey-700">{{ t('common.loading') }}</p>
-  </AuthWrapper>
+    <Spinner v-else />
+  </div>
 </template>


### PR DESCRIPTION
Follow-up to #232. The outbound redirect is blank now, but the **inbound** `/auth/callback` still rendered `AuthWrapper` (the login-page background + logo) while exchanging the code — so coming back from the auth app flashed a login-page look before the inquiry list. Render a neutral centered spinner instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)