### PR TITLE
feat(auth): RP-initiated logout + header app-switcher dropdown

### DIFF
--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from 'pinia'
 import ExitIcon from '@assets/svg/icons/exit.svg'
 
 import { useSessionStore } from '@/stores/session'
+import { logoutRedirect } from '@/services/oidc'
 
 const sessionStore = useSessionStore()
 const { currentUser } = storeToRefs(sessionStore)
@@ -25,8 +26,9 @@ const initials = computed(() => {
   return (u.email?.slice(0, 2) ?? '??').toUpperCase()
 })
 
-async function handleLogout() {
-  await sessionStore.logoutAndRedirect()
+function handleLogout() {
+  // RP-initiated logout — ends the SSO session at the provider (see oidc.ts).
+  logoutRedirect()
 }
 </script>
 

--- a/src/services/fundermaps/session.ts
+++ b/src/services/fundermaps/session.ts
@@ -5,6 +5,9 @@
  */
 
 const TOKEN_KEY = 'access_token'
+// The OIDC id_token, kept only for `id_token_hint` on RP-initiated logout
+// (/oauth2/end-session). Not used for API auth — that's the access token.
+const ID_TOKEN_KEY = 'id_token'
 
 export function storeAccessToken(token: string): void {
   localStorage.setItem(TOKEN_KEY, token)
@@ -20,4 +23,16 @@ export function getAccessToken(): string | null {
 
 export function hasAccessToken(): boolean {
   return getAccessToken() !== null
+}
+
+export function storeIdToken(token: string): void {
+  localStorage.setItem(ID_TOKEN_KEY, token)
+}
+
+export function getIdToken(): string | null {
+  return localStorage.getItem(ID_TOKEN_KEY)
+}
+
+export function removeIdToken(): void {
+  localStorage.removeItem(ID_TOKEN_KEY)
 }

--- a/src/services/oidc.ts
+++ b/src/services/oidc.ts
@@ -8,7 +8,13 @@
  * and no refresh token for now (the access token is re-obtained by bouncing
  * through /authorize again, which is silent while the SSO session is alive).
  */
-import { storeAccessToken } from './fundermaps/session'
+import {
+  getIdToken,
+  removeAccessToken,
+  removeIdToken,
+  storeAccessToken,
+  storeIdToken,
+} from './fundermaps/session'
 
 const API = (import.meta.env.VITE_FUNDERMAPS_URL || '').replace(/\/+$/, '')
 const CLIENT_ID = 'clientapp'
@@ -76,10 +82,40 @@ export async function exchangeCode(code: string, state: string): Promise<void> {
   if (!res.ok) {
     throw new Error(`Token exchange failed (${res.status})`)
   }
-  const tokens = (await res.json()) as { access_token?: string }
+  const tokens = (await res.json()) as { access_token?: string; id_token?: string }
   if (!tokens.access_token) throw new Error('No access token in token response')
 
   storeAccessToken(tokens.access_token)
+  if (tokens.id_token) storeIdToken(tokens.id_token)
   sessionStorage.removeItem(VERIFIER_KEY)
   sessionStorage.removeItem(STATE_KEY)
+}
+
+/**
+ * RP-initiated logout: clear local tokens, then end the SSO session at the
+ * provider via /oauth2/end-session (id_token_hint identifies the session). The
+ * provider clears the Better Auth session cookie and redirects to
+ * post_logout_redirect_uri — here /login, which re-enters the flow and (now
+ * that the SSO session is gone) shows a fresh login prompt.
+ *
+ * Without ending the SSO session, a local-only logout would just bounce back
+ * through /authorize and silently log the user straight back in.
+ */
+export function logoutRedirect(): void {
+  const idToken = getIdToken()
+  removeAccessToken()
+  removeIdToken()
+
+  const postLogout = `${window.location.origin}/login`
+  if (!idToken) {
+    // No id_token to prove the session — best effort: just go to login.
+    window.location.assign(postLogout)
+    return
+  }
+  const params = new URLSearchParams({
+    id_token_hint: idToken,
+    post_logout_redirect_uri: postLogout,
+    client_id: CLIENT_ID,
+  })
+  window.location.assign(`${API}/api/auth/oauth2/end-session?${params.toString()}`)
 }

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -7,6 +7,7 @@ import {
   getAccessToken,
   hasAccessToken,
   removeAccessToken,
+  removeIdToken,
   storeAccessToken,
 } from '@/services/fundermaps/session'
 import type { IUser, OrgRole } from '@/services/fundermaps/interfaces/IUser'
@@ -56,6 +57,7 @@ async function authenticateFromAccessToken() {
 
 function clearLocalSession() {
   removeAccessToken()
+  removeIdToken()
   currentUser.value = null
 }
 

--- a/src/views/auth/Logout.vue
+++ b/src/views/auth/Logout.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
-import { useSessionStore } from '@/stores/session'
+import { logoutRedirect } from '@/services/oidc'
 
-const sessionStore = useSessionStore()
-
-onMounted(async () => {
-  await sessionStore.logoutAndRedirect()
+// RP-initiated logout: clear local tokens and end the SSO session at the
+// provider (/oauth2/end-session), then land back on /login for a fresh login
+// (option B). A local-only logout would silently re-login via the still-alive
+// SSO session.
+onMounted(() => {
+  logoutRedirect()
 })
 </script>
 


### PR DESCRIPTION
Two related header/logout changes (deploy together; both touch the user menu).

## 1. RP-initiated logout
Logout cleared only the local token, then bounced through `/authorize` — which, seeing the still-alive **SSO session**, silently logged the user right back in. Now logout ends the SSO session at the provider:
- Store the `id_token` (for `id_token_hint`); `clearLocalSession` drops it.
- `oidc.logoutRedirect()`: clear tokens → `/oauth2/end-session?id_token_hint=…&post_logout_redirect_uri=…/login` → provider ends the BA session → fresh login (option B).
- Wired into both the `/logout` route **and** the header logout button (UserMenu).
- **Requires** FunderMapsWorker#24 (`enable_end_session` + `post_logout_redirect_uris` on the `clientapp` client).
- Verified locally: `end-session` → 302 to post-logout URI; `get-session` → `null` after.

## 2. Header app-switcher dropdown
The header user menu is now a dropdown: **Andere apps** (Maps for everyone; Beheer/admin gated to `role==='administrator'`; Report omitted — PDF-only) + **Logout** (RP-initiated). Closes on outside-click / Escape. App URLs hardcoded for the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
