### PR TITLE
fix(ui): remove white strip between header and content

### DIFF
--- a/src/styles/pages/dashboard.css
+++ b/src/styles/pages/dashboard.css
@@ -2,7 +2,9 @@
   @apply grid;
 
   grid-template-columns: [panel-left full-start] 21rem [main] auto [panel-right] 21rem [full-end];
-  grid-template-rows: [header] theme(spacing.20) [main] auto;
+  /* Header row must match the fixed .app-header height (h-16 = 4rem). A taller
+     row leaves a white strip between the header and the grey .app-view. */
+  grid-template-rows: [header] theme(spacing.16) [main] auto;
 
   .app-header {
     grid-column: full;


### PR DESCRIPTION
The `.page-dashboard` grid reserved a **5rem** (`spacing.20`) header row, but the fixed `.app-header` is **`h-16`** (4rem). So the grey `.app-view` started 16px below the header's bottom edge, exposing the page background as a white line between the header and the content.

Fix: match the header row to the header height — `grid-template-rows: [header] theme(spacing.16) …` (4rem) — with a comment noting the coupling.

`pnpm build` passes; bundle confirms `grid-template-rows:[header]4rem[main]auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)