### PR TITLE
refactor(ui): redesign the inquiry / recovery wizards to the new style

### DIFF
--- a/src/components/Common/WizardSteps.vue
+++ b/src/components/Common/WizardSteps.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    steps: string[]
+    current: number // 1-indexed
+  }>(),
+  {},
+)
+</script>
+
+<template>
+  <ol class="flex flex-wrap items-center gap-2 text-sm">
+    <template v-for="(label, idx) in steps" :key="idx">
+      <li class="flex items-center gap-2">
+        <span
+          class="inline-flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold"
+          :class="
+            idx + 1 === current
+              ? 'border-green-500 bg-green-500 text-white'
+              : idx + 1 < current
+                ? 'border-green-500 bg-green-50 text-green-700'
+                : 'border-grey-200 bg-white text-grey-700'
+          "
+        >
+          {{ idx + 1 }}
+        </span>
+        <span
+          class="font-medium"
+          :class="idx + 1 === current ? 'text-grey-800' : 'text-grey-700'"
+        >
+          {{ label }}
+        </span>
+      </li>
+      <li
+        v-if="idx < steps.length - 1"
+        class="text-grey-400"
+        aria-hidden="true"
+      >
+        ›
+      </li>
+    </template>
+  </ol>
+</template>

--- a/src/views/inquiry/InquiryStep1.vue
+++ b/src/views/inquiry/InquiryStep1.vue
@@ -13,6 +13,8 @@ import Select from '@/components/Common/Inputs/Select.vue'
 import CheckBox from '@/components/Common/Inputs/CheckBox.vue'
 import Textarea from '@/components/Common/Inputs/Textarea.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type { IContractor } from '@/services/fundermaps/interfaces/IContractor'
@@ -177,23 +179,39 @@ onBeforeMount(async () => {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'inquiry-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
-        <h2 class="heading-3">
-          {{ isNew ? 'Nieuwe rapportage' : 'Rapportage bewerken' }} — gegevens (stap 1 van 3)
-        </h2>
-      </header>
-      <Spinner v-if="loading" />
+        ← {{ t('inquiry.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-semibold text-grey-800">
+            {{ isNew ? 'Nieuwe rapportage' : 'Rapportage bewerken' }}
+          </h2>
+          <p class="mt-0.5 text-sm text-grey-700">
+            Vul de basisgegevens van het rapport in en upload het document.
+          </p>
+        </div>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="1" />
+    </div>
+
+    <Alert v-if="saveError" :closeable="true" class="mb-3" @close="saveError = null">
+      {{ saveError }}
+    </Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
-      <Alert v-if="saveError" :closeable="true" @close="saveError = null">{{ saveError }}</Alert>
     </Card>
 
-    <Card v-if="!loading" class="List col-span-3">
+    <Card v-else>
       <form class="space-y-8" @submit.prevent="onSubmit">
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Rapport
           </h4>
           <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -247,7 +265,7 @@ onBeforeMount(async () => {
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Document
           </h4>
           <div class="space-y-2">
@@ -272,7 +290,7 @@ onBeforeMount(async () => {
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Eigenschappen
           </h4>
           <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
@@ -284,13 +302,13 @@ onBeforeMount(async () => {
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Notitie
           </h4>
           <Textarea v-model="formData.note" placeholder="Optionele notitie…" :rows="4" />
         </section>
 
-        <div class="-mx-5 -mb-5 flex justify-end gap-3 border-t border-grey-200 px-5 py-4">
+        <div class="flex justify-end gap-2 border-t border-grey-200 pt-4">
           <Button
             label="Opslaan en verder"
             type="submit"

--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -10,6 +10,8 @@ import Alert from '@/components/Common/Alert.vue'
 import AddressPicker from '@/components/Inquiry/AddressPicker.vue'
 import SampleForm from '@/components/Inquiry/SampleForm.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type { IInquirySample, IInquirySampleInput } from '@/services/fundermaps/interfaces/IInquirySample'
@@ -201,61 +203,85 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'inquiry-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
-        <h2 class="heading-3">Rapportage — adressen (stap 2 van 3)</h2>
+        ← {{ t('inquiry.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-semibold text-grey-800">Adressen</h2>
+          <p class="mt-0.5 text-sm text-grey-700">
+            Zoek adressen en vul per locatie de bevindingen in.
+          </p>
+        </div>
         <div class="flex gap-2">
-          <Button label="Vorige" outline @click="previous" />
+          <Button outline label="Vorige" @click="previous" />
           <Button label="Volgende" @click="next" />
         </div>
-      </header>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="2" />
+    </div>
 
-      <Alert v-if="loadError" :closeable="true" @close="loadError = null">{{ loadError }}</Alert>
-      <Alert v-if="actionError" :closeable="true" @close="actionError = null">{{
-        actionError
-      }}</Alert>
+    <Alert v-if="loadError" :closeable="true" class="mb-3" @close="loadError = null">
+      {{ loadError }}
+    </Alert>
+    <Alert v-if="actionError" :closeable="true" class="mb-3" @close="actionError = null">
+      {{ actionError }}
+    </Alert>
 
-      <Spinner v-if="loading" />
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
-    <template v-if="!loading">
-      <Card class="List col-span-3 lg:col-span-1">
-        <header class="-mx-5 -mt-5 border-b border-grey-200 px-5 py-4">
-          <h3 class="heading-3">Adressen</h3>
-          <p class="mt-1 text-xs text-grey-700">
-            Zoek het adres en klik op een suggestie om toe te voegen.
+    <div v-else class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <Card class="lg:col-span-1 !p-0">
+        <header class="border-b border-grey-200 px-4 py-3">
+          <h3 class="text-sm font-semibold text-grey-800">Adressen ({{ samples.length }})</h3>
+          <p class="mt-0.5 text-xs text-grey-700">
+            Zoek een adres en klik op een suggestie om toe te voegen.
           </p>
         </header>
 
-        <AddressPicker @pick="handlePick" />
+        <div class="px-4 py-3">
+          <AddressPicker @pick="handlePick" />
+        </div>
 
-        <ul v-if="samples.length" class="divide-y divide-grey-200">
+        <ul v-if="samples.length" class="divide-y divide-grey-200 border-t border-grey-200">
           <li
             v-for="s in samples"
             :key="s.id"
-            class="cursor-pointer px-2 py-2 text-sm hover:bg-grey-100"
-            :class="s.id === selectedId ? 'bg-green-100 font-semibold' : 'text-grey-800'"
+            class="cursor-pointer px-4 py-2 text-sm transition-colors"
+            :class="
+              s.id === selectedId
+                ? 'bg-grey-100 font-semibold text-grey-800'
+                : 'text-grey-800 hover:bg-grey-100'
+            "
             @click="selectSample(s.id)"
           >
             {{ formatAddress(addressStore.cache[s.address]) }}
           </li>
         </ul>
-        <p v-else class="text-sm text-grey-700">Nog geen adressen. Begin hierboven met zoeken.</p>
+        <p v-else class="border-t border-grey-200 px-4 py-3 text-sm text-grey-700">
+          Nog geen adressen. Begin hierboven met zoeken.
+        </p>
       </Card>
 
-      <Card v-if="!selected" class="List col-span-3 lg:col-span-2">
-        <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
-      </Card>
-      <SampleForm
-        v-else
-        :sample="selected"
-        :saving="saving"
-        @save="handleSave"
-        @delete="handleDelete"
-      />
-    </template>
+      <div class="lg:col-span-2">
+        <Card v-if="!selected" class="flex items-center justify-center py-12">
+          <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
+        </Card>
+        <SampleForm
+          v-else
+          :sample="selected"
+          :saving="saving"
+          @save="handleSave"
+          @delete="handleDelete"
+        />
+      </div>
+    </div>
   </MainWrapper>
 </template>

--- a/src/views/inquiry/InquiryStep3.vue
+++ b/src/views/inquiry/InquiryStep3.vue
@@ -9,6 +9,8 @@ import Button from '@/components/Common/Buttons/Button.vue'
 import Alert from '@/components/Common/Alert.vue'
 import StatusBadge from '@/components/Common/StatusBadge.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type { IInquiry } from '@/services/fundermaps/interfaces/IInquiry'
@@ -83,68 +85,82 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'inquiry-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
+        ← {{ t('inquiry.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="heading-3">Rapportage — controle (stap 3 van 3)</h2>
-          <div v-if="inquiry" class="mt-1 flex items-center gap-2 text-sm text-grey-700">
+          <h2 class="text-xl font-semibold text-grey-800">Controle</h2>
+          <p v-if="inquiry" class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
             <span>{{ inquiryTypeLabel(inquiry.type) }}</span>
-            <span>·</span>
+            <span aria-hidden="true">·</span>
             <span>{{ formatDate(inquiry.documentDate) }}</span>
             <StatusBadge :status="inquiry.state.auditStatus" />
-          </div>
+          </p>
         </div>
         <div class="flex gap-2">
-          <Button label="Vorige" outline @click="previous" />
+          <Button outline label="Vorige" @click="previous" />
           <Button
             label="Aanbieden ter review"
             :disabled="!canSubmit || submitting"
             @click="submit"
           />
         </div>
-      </header>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="3" />
+    </div>
 
-      <Alert v-if="error" :closeable="true" @close="error = null">{{ error }}</Alert>
-      <Spinner v-if="loading" />
+    <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">{{ error }}</Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
+    </Card>
 
-      <div v-if="inquiry" class="space-y-8">
+    <Card v-else-if="inquiry">
+      <div class="space-y-6">
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Rapport
           </h4>
-          <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
-            <dt class="font-medium text-grey-700">Naam</dt>
-            <dd class="sm:col-span-2">{{ inquiry.documentName }}</dd>
+          <dl class="grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt class="text-grey-700">Naam</dt>
+            <dd class="text-grey-800">{{ inquiry.documentName }}</dd>
 
-            <dt class="font-medium text-grey-700">Opsteller</dt>
-            <dd class="sm:col-span-2">{{ inquiry.attribution.creatorName ?? '-' }}</dd>
+            <dt class="text-grey-700">Opsteller</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.creatorName ?? '—' }}</dd>
 
-            <dt class="font-medium text-grey-700">Beoordelaar</dt>
-            <dd class="sm:col-span-2">{{ inquiry.attribution.reviewerName ?? '-' }}</dd>
+            <dt class="text-grey-700">Beoordelaar</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.reviewerName ?? '—' }}</dd>
 
-            <dt class="font-medium text-grey-700">Uitvoerder</dt>
-            <dd class="sm:col-span-2">{{ inquiry.attribution.contractorName ?? '-' }}</dd>
+            <dt class="text-grey-700">Uitvoerder</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.contractorName ?? '—' }}</dd>
 
-            <dt v-if="inquiry.note" class="font-medium text-grey-700">Notitie</dt>
-            <dd v-if="inquiry.note" class="whitespace-pre-wrap sm:col-span-2">
-              {{ inquiry.note }}
-            </dd>
+            <template v-if="inquiry.note">
+              <dt class="text-grey-700">Notitie</dt>
+              <dd class="whitespace-pre-wrap text-grey-800">{{ inquiry.note }}</dd>
+            </template>
           </dl>
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Adressen ({{ samples.length }})
           </h4>
-          <p v-if="samples.length === 0" class="text-sm text-red-500">
+          <Alert v-if="samples.length === 0" type="warning">
             Voeg minimaal één adres toe in stap 2 voordat je het rapport indient.
-          </p>
-          <ul v-else class="divide-y divide-grey-200">
-            <li v-for="s in samples" :key="s.id" class="py-3 text-sm">
-              <p class="font-semibold text-grey-800">
+          </Alert>
+          <ul v-else class="overflow-hidden rounded-md border border-grey-200">
+            <li
+              v-for="s in samples"
+              :key="s.id"
+              class="space-y-1 border-b border-grey-200 px-3 py-3 text-sm last:border-b-0"
+            >
+              <p class="font-medium text-grey-800">
                 {{ formatAddress(addressStore.cache[s.address]) }}
               </p>
               <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>

--- a/src/views/inquiry/InquiryView.vue
+++ b/src/views/inquiry/InquiryView.vue
@@ -140,32 +140,30 @@ async function handleDelete() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <RouterLink :to="{ name: 'inquiry-list' }" class="text-sm text-green-700 hover:underline">
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'inquiry-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
+      >
         ← {{ t('inquiry.view.back') }}
       </RouterLink>
 
-      <Spinner v-if="loading" />
-      <span v-if="false">{{ t('common.loading') }}</span>
-      <Alert v-if="error" :closeable="true" @close="error = null">{{ error }}</Alert>
-
       <template v-if="inquiry">
-        <header
-          class="-mx-5 flex flex-wrap items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
-        >
-          <div class="space-y-1">
-            <h2 class="heading-3">{{ inquiry.documentName }}</h2>
-            <div class="flex items-center gap-2 text-sm text-grey-700">
-              <span>{{ inquiryTypeLabel(inquiry.type) }}</span>
-              <span>·</span>
-              <span>{{ formatDate(inquiry.documentDate) }}</span>
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-xl font-semibold text-grey-800">{{ inquiry.documentName }}</h2>
               <StatusBadge :status="inquiry.state.auditStatus" />
             </div>
+            <p class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
+              <span>{{ inquiryTypeLabel(inquiry.type) }}</span>
+              <span aria-hidden="true">·</span>
+              <span>{{ formatDate(inquiry.documentDate) }}</span>
+            </p>
           </div>
-
           <div class="flex flex-wrap gap-2">
-            <Button label="Document" outline @click="handleDownload" />
-            <Button v-if="isEditable && canWrite" label="Bewerken" outline @click="goEdit" />
+            <Button outline label="Document" @click="handleDownload" />
+            <Button v-if="isEditable && canWrite" outline label="Bewerken" @click="goEdit" />
             <Button
               v-if="canSubmitForReview && canWrite"
               label="Aanbieden ter review"
@@ -178,75 +176,82 @@ async function handleDelete() {
             />
             <Button
               v-if="isPendingReview && canApprove"
-              label="Afkeuren"
               danger
+              label="Afkeuren"
               @click="showRejectModal = true"
             />
-            <Button
-              v-if="isSuperUser"
-              label="Verwijderen"
-              danger
-              @click="handleDelete"
-            />
+            <Button v-if="isSuperUser" danger label="Verwijderen" @click="handleDelete" />
           </div>
-        </header>
-
-        <Alert v-if="actionError" :closeable="true" @close="actionError = null">
-          {{ actionError }}
-        </Alert>
-
-        <div class="space-y-8">
-          <section>
-            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
-              Details
-            </h4>
-            <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
-              <dt class="font-medium text-grey-700">Opsteller</dt>
-              <dd class="sm:col-span-2">{{ inquiry.attribution.creatorName ?? '-' }}</dd>
-
-              <dt class="font-medium text-grey-700">Beoordelaar</dt>
-              <dd class="sm:col-span-2">{{ inquiry.attribution.reviewerName ?? '-' }}</dd>
-
-              <dt class="font-medium text-grey-700">Uitvoerder</dt>
-              <dd class="sm:col-span-2">{{ inquiry.attribution.contractorName ?? '-' }}</dd>
-
-              <dt class="font-medium text-grey-700">Inspectie</dt>
-              <dd class="sm:col-span-2">{{ inquiry.inspection ? 'Ja' : 'Nee' }}</dd>
-
-              <dt class="font-medium text-grey-700">Voegmeting</dt>
-              <dd class="sm:col-span-2">{{ inquiry.jointMeasurement ? 'Ja' : 'Nee' }}</dd>
-
-              <dt class="font-medium text-grey-700">Vloermeting</dt>
-              <dd class="sm:col-span-2">{{ inquiry.floorMeasurement ? 'Ja' : 'Nee' }}</dd>
-
-              <dt class="font-medium text-grey-700">F3O standaard</dt>
-              <dd class="sm:col-span-2">{{ inquiry.standardF3o ? 'Ja' : 'Nee' }}</dd>
-
-              <dt v-if="inquiry.note" class="font-medium text-grey-700">Notitie</dt>
-              <dd v-if="inquiry.note" class="whitespace-pre-wrap sm:col-span-2">
-                {{ inquiry.note }}
-              </dd>
-            </dl>
-          </section>
-
-          <section>
-            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
-              Adressen ({{ samples.length }})
-            </h4>
-            <p v-if="samples.length === 0" class="text-sm text-grey-700">
-              Nog geen adressen toegevoegd.
-            </p>
-            <ul v-else class="divide-y divide-grey-200">
-              <li v-for="s in samples" :key="s.id" class="space-y-1 py-3 text-sm">
-                <p class="font-semibold text-grey-800">
-                  {{ formatAddress(addressStore.cache[s.address]) }}
-                </p>
-                <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>
-              </li>
-            </ul>
-          </section>
         </div>
       </template>
+    </div>
+
+    <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">{{ error }}</Alert>
+    <Alert v-if="actionError" :closeable="true" class="mb-3" @close="actionError = null">
+      {{ actionError }}
+    </Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
+      <span v-if="false">{{ t('common.loading') }}</span>
+    </Card>
+
+    <Card v-else-if="inquiry">
+      <div class="space-y-6">
+        <section>
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
+            Details
+          </h4>
+          <dl class="grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt class="text-grey-700">Opsteller</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.creatorName ?? '—' }}</dd>
+
+            <dt class="text-grey-700">Beoordelaar</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.reviewerName ?? '—' }}</dd>
+
+            <dt class="text-grey-700">Uitvoerder</dt>
+            <dd class="text-grey-800">{{ inquiry.attribution.contractorName ?? '—' }}</dd>
+
+            <dt class="text-grey-700">Inspectie</dt>
+            <dd class="text-grey-800">{{ inquiry.inspection ? 'Ja' : 'Nee' }}</dd>
+
+            <dt class="text-grey-700">Voegmeting</dt>
+            <dd class="text-grey-800">{{ inquiry.jointMeasurement ? 'Ja' : 'Nee' }}</dd>
+
+            <dt class="text-grey-700">Vloermeting</dt>
+            <dd class="text-grey-800">{{ inquiry.floorMeasurement ? 'Ja' : 'Nee' }}</dd>
+
+            <dt class="text-grey-700">F3O standaard</dt>
+            <dd class="text-grey-800">{{ inquiry.standardF3o ? 'Ja' : 'Nee' }}</dd>
+
+            <template v-if="inquiry.note">
+              <dt class="text-grey-700">Notitie</dt>
+              <dd class="whitespace-pre-wrap text-grey-800">{{ inquiry.note }}</dd>
+            </template>
+          </dl>
+        </section>
+
+        <section>
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
+            Adressen ({{ samples.length }})
+          </h4>
+          <p v-if="samples.length === 0" class="text-sm text-grey-700">
+            Nog geen adressen toegevoegd.
+          </p>
+          <ul v-else class="overflow-hidden rounded-md border border-grey-200">
+            <li
+              v-for="s in samples"
+              :key="s.id"
+              class="space-y-1 border-b border-grey-200 px-3 py-3 text-sm last:border-b-0"
+            >
+              <p class="font-medium text-grey-800">
+                {{ formatAddress(addressStore.cache[s.address]) }}
+              </p>
+              <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>
+            </li>
+          </ul>
+        </section>
+      </div>
     </Card>
 
     <RejectModal v-if="showRejectModal" @close="showRejectModal = false" @submit="handleReject" />

--- a/src/views/recovery/RecoveryStep1.vue
+++ b/src/views/recovery/RecoveryStep1.vue
@@ -12,6 +12,8 @@ import Input from '@/components/Common/Inputs/Input.vue'
 import Select from '@/components/Common/Inputs/Select.vue'
 import Textarea from '@/components/Common/Inputs/Textarea.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type { IContractor } from '@/services/fundermaps/interfaces/IContractor'
@@ -160,23 +162,39 @@ onBeforeMount(async () => {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'recovery-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
-        <h2 class="heading-3">
-          {{ isNew ? 'Nieuw herstel' : 'Herstel bewerken' }} — gegevens (stap 1 van 3)
-        </h2>
-      </header>
-      <Spinner v-if="loading" />
+        ← {{ t('recovery.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-semibold text-grey-800">
+            {{ isNew ? 'Nieuw herstel' : 'Herstel bewerken' }}
+          </h2>
+          <p class="mt-0.5 text-sm text-grey-700">
+            Vul de basisgegevens van het herstel-dossier in en upload het document.
+          </p>
+        </div>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="1" />
+    </div>
+
+    <Alert v-if="saveError" :closeable="true" class="mb-3" @close="saveError = null">
+      {{ saveError }}
+    </Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
-      <Alert v-if="saveError" :closeable="true" @close="saveError = null">{{ saveError }}</Alert>
     </Card>
 
-    <Card v-if="!loading" class="List col-span-3">
+    <Card v-else>
       <form class="space-y-8" @submit.prevent="onSubmit">
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Document
           </h4>
           <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -230,7 +248,7 @@ onBeforeMount(async () => {
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Bestand
           </h4>
           <div class="space-y-2">
@@ -255,13 +273,13 @@ onBeforeMount(async () => {
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Notitie
           </h4>
           <Textarea v-model="formData.note" placeholder="Optionele notitie…" :rows="4" />
         </section>
 
-        <div class="-mx-5 -mb-5 flex justify-end gap-3 border-t border-grey-200 px-5 py-4">
+        <div class="flex justify-end gap-2 border-t border-grey-200 pt-4">
           <Button
             label="Opslaan en verder"
             type="submit"

--- a/src/views/recovery/RecoveryStep2.vue
+++ b/src/views/recovery/RecoveryStep2.vue
@@ -10,6 +10,8 @@ import Alert from '@/components/Common/Alert.vue'
 import AddressPicker from '@/components/Inquiry/AddressPicker.vue'
 import SampleForm from '@/components/Recovery/SampleForm.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type {
@@ -155,61 +157,85 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'recovery-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
-        <h2 class="heading-3">Herstel — adressen (stap 2 van 3)</h2>
+        ← {{ t('recovery.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-semibold text-grey-800">Adressen</h2>
+          <p class="mt-0.5 text-sm text-grey-700">
+            Zoek adressen en vul per locatie de herstel-gegevens in.
+          </p>
+        </div>
         <div class="flex gap-2">
-          <Button label="Vorige" outline @click="previous" />
+          <Button outline label="Vorige" @click="previous" />
           <Button label="Volgende" @click="next" />
         </div>
-      </header>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="2" />
+    </div>
 
-      <Alert v-if="loadError" :closeable="true" @close="loadError = null">{{ loadError }}</Alert>
-      <Alert v-if="actionError" :closeable="true" @close="actionError = null">{{
-        actionError
-      }}</Alert>
+    <Alert v-if="loadError" :closeable="true" class="mb-3" @close="loadError = null">
+      {{ loadError }}
+    </Alert>
+    <Alert v-if="actionError" :closeable="true" class="mb-3" @close="actionError = null">
+      {{ actionError }}
+    </Alert>
 
-      <Spinner v-if="loading" />
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
-    <template v-if="!loading">
-      <Card class="List col-span-3 lg:col-span-1">
-        <header class="-mx-5 -mt-5 border-b border-grey-200 px-5 py-4">
-          <h3 class="heading-3">Adressen</h3>
-          <p class="mt-1 text-xs text-grey-700">
-            Zoek het adres en klik op een suggestie om toe te voegen.
+    <div v-else class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <Card class="lg:col-span-1 !p-0">
+        <header class="border-b border-grey-200 px-4 py-3">
+          <h3 class="text-sm font-semibold text-grey-800">Adressen ({{ samples.length }})</h3>
+          <p class="mt-0.5 text-xs text-grey-700">
+            Zoek een adres en klik op een suggestie om toe te voegen.
           </p>
         </header>
 
-        <AddressPicker @pick="handlePick" />
+        <div class="px-4 py-3">
+          <AddressPicker @pick="handlePick" />
+        </div>
 
-        <ul v-if="samples.length" class="divide-y divide-grey-200">
+        <ul v-if="samples.length" class="divide-y divide-grey-200 border-t border-grey-200">
           <li
             v-for="s in samples"
             :key="s.id"
-            class="cursor-pointer px-2 py-2 text-sm hover:bg-grey-100"
-            :class="s.id === selectedId ? 'bg-green-100 font-semibold' : 'text-grey-800'"
+            class="cursor-pointer px-4 py-2 text-sm transition-colors"
+            :class="
+              s.id === selectedId
+                ? 'bg-grey-100 font-semibold text-grey-800'
+                : 'text-grey-800 hover:bg-grey-100'
+            "
             @click="selectSample(s.id)"
           >
             {{ formatAddress(addressStore.cache[s.building]) }}
           </li>
         </ul>
-        <p v-else class="text-sm text-grey-700">Nog geen adressen. Begin hierboven met zoeken.</p>
+        <p v-else class="border-t border-grey-200 px-4 py-3 text-sm text-grey-700">
+          Nog geen adressen. Begin hierboven met zoeken.
+        </p>
       </Card>
 
-      <Card v-if="!selected" class="List col-span-3 lg:col-span-2">
-        <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
-      </Card>
-      <SampleForm
-        v-else
-        :sample="selected"
-        :saving="saving"
-        @save="handleSave"
-        @delete="handleDelete"
-      />
-    </template>
+      <div class="lg:col-span-2">
+        <Card v-if="!selected" class="flex items-center justify-center py-12">
+          <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
+        </Card>
+        <SampleForm
+          v-else
+          :sample="selected"
+          :saving="saving"
+          @save="handleSave"
+          @delete="handleDelete"
+        />
+      </div>
+    </div>
   </MainWrapper>
 </template>

--- a/src/views/recovery/RecoveryStep3.vue
+++ b/src/views/recovery/RecoveryStep3.vue
@@ -9,6 +9,8 @@ import Button from '@/components/Common/Buttons/Button.vue'
 import Alert from '@/components/Common/Alert.vue'
 import StatusBadge from '@/components/Common/StatusBadge.vue'
 import Spinner from '@/components/Common/Spinner.vue'
+import WizardSteps from '@/components/Common/WizardSteps.vue'
+import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
 import type { IRecovery } from '@/services/fundermaps/interfaces/IRecovery'
@@ -83,68 +85,82 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <header
-        class="-mx-5 -mt-5 flex items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'recovery-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
       >
+        ← {{ t('recovery.view.back') }}
+      </RouterLink>
+      <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="heading-3">Herstel — controle (stap 3 van 3)</h2>
-          <div v-if="recovery" class="mt-1 flex items-center gap-2 text-sm text-grey-700">
+          <h2 class="text-xl font-semibold text-grey-800">Controle</h2>
+          <p v-if="recovery" class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
             <span>{{ recoveryDocumentTypeLabel(recovery.type) }}</span>
-            <span>·</span>
+            <span aria-hidden="true">·</span>
             <span>{{ formatDate(recovery.documentDate) }}</span>
             <StatusBadge :status="recovery.state.auditStatus" />
-          </div>
+          </p>
         </div>
         <div class="flex gap-2">
-          <Button label="Vorige" outline @click="previous" />
+          <Button outline label="Vorige" @click="previous" />
           <Button
             label="Aanbieden ter review"
             :disabled="!canSubmit || submitting"
             @click="submit"
           />
         </div>
-      </header>
+      </div>
+      <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="3" />
+    </div>
 
-      <Alert v-if="error" :closeable="true" @close="error = null">{{ error }}</Alert>
-      <Spinner v-if="loading" />
+    <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">{{ error }}</Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
       <span v-if="false">{{ t('common.loading') }}</span>
+    </Card>
 
-      <div v-if="recovery" class="space-y-8">
+    <Card v-else-if="recovery">
+      <div class="space-y-6">
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Document
           </h4>
-          <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
-            <dt class="font-medium text-grey-700">Naam</dt>
-            <dd class="sm:col-span-2">{{ recovery.documentName }}</dd>
+          <dl class="grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt class="text-grey-700">Naam</dt>
+            <dd class="text-grey-800">{{ recovery.documentName }}</dd>
 
-            <dt class="font-medium text-grey-700">Opsteller</dt>
-            <dd class="sm:col-span-2">{{ recovery.attribution.creatorName ?? '-' }}</dd>
+            <dt class="text-grey-700">Opsteller</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.creatorName ?? '—' }}</dd>
 
-            <dt class="font-medium text-grey-700">Beoordelaar</dt>
-            <dd class="sm:col-span-2">{{ recovery.attribution.reviewerName ?? '-' }}</dd>
+            <dt class="text-grey-700">Beoordelaar</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.reviewerName ?? '—' }}</dd>
 
-            <dt class="font-medium text-grey-700">Uitvoerder</dt>
-            <dd class="sm:col-span-2">{{ recovery.attribution.contractorName ?? '-' }}</dd>
+            <dt class="text-grey-700">Uitvoerder</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.contractorName ?? '—' }}</dd>
 
-            <dt v-if="recovery.note" class="font-medium text-grey-700">Notitie</dt>
-            <dd v-if="recovery.note" class="whitespace-pre-wrap sm:col-span-2">
-              {{ recovery.note }}
-            </dd>
+            <template v-if="recovery.note">
+              <dt class="text-grey-700">Notitie</dt>
+              <dd class="whitespace-pre-wrap text-grey-800">{{ recovery.note }}</dd>
+            </template>
           </dl>
         </section>
 
         <section>
-          <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Adressen ({{ samples.length }})
           </h4>
-          <p v-if="samples.length === 0" class="text-sm text-red-500">
+          <Alert v-if="samples.length === 0" type="warning">
             Voeg minimaal één adres toe in stap 2 voordat je het herstel indient.
-          </p>
-          <ul v-else class="divide-y divide-grey-200">
-            <li v-for="s in samples" :key="s.id" class="py-3 text-sm">
-              <p class="font-semibold text-grey-800">
+          </Alert>
+          <ul v-else class="overflow-hidden rounded-md border border-grey-200">
+            <li
+              v-for="s in samples"
+              :key="s.id"
+              class="space-y-1 border-b border-grey-200 px-3 py-3 text-sm last:border-b-0"
+            >
+              <p class="font-medium text-grey-800">
                 {{ formatAddress(addressStore.cache[s.building]) }}
               </p>
               <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>

--- a/src/views/recovery/RecoveryView.vue
+++ b/src/views/recovery/RecoveryView.vue
@@ -143,32 +143,30 @@ async function handleDelete() {
 
 <template>
   <MainWrapper>
-    <Card class="List col-span-3 mt-16">
-      <RouterLink :to="{ name: 'recovery-list' }" class="text-sm text-green-700 hover:underline">
+    <div class="mb-5 space-y-3">
+      <RouterLink
+        :to="{ name: 'recovery-list' }"
+        class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
+      >
         ← {{ t('recovery.view.back') }}
       </RouterLink>
 
-      <Spinner v-if="loading" />
-      <span v-if="false">{{ t('common.loading') }}</span>
-      <Alert v-if="error" :closeable="true" @close="error = null">{{ error }}</Alert>
-
       <template v-if="recovery">
-        <header
-          class="-mx-5 flex flex-wrap items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
-        >
-          <div class="space-y-1">
-            <h2 class="heading-3">{{ recovery.documentName }}</h2>
-            <div class="flex items-center gap-2 text-sm text-grey-700">
-              <span>{{ recoveryDocumentTypeLabel(recovery.type) }}</span>
-              <span>·</span>
-              <span>{{ formatDate(recovery.documentDate) }}</span>
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-xl font-semibold text-grey-800">{{ recovery.documentName }}</h2>
               <StatusBadge :status="recovery.state.auditStatus" />
             </div>
+            <p class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
+              <span>{{ recoveryDocumentTypeLabel(recovery.type) }}</span>
+              <span aria-hidden="true">·</span>
+              <span>{{ formatDate(recovery.documentDate) }}</span>
+            </p>
           </div>
-
           <div class="flex flex-wrap gap-2">
-            <Button label="Document" outline @click="handleDownload" />
-            <Button v-if="isEditable && canWrite" label="Bewerken" outline @click="goEdit" />
+            <Button outline label="Document" @click="handleDownload" />
+            <Button v-if="isEditable && canWrite" outline label="Bewerken" @click="goEdit" />
             <Button
               v-if="canSubmitForReview && canWrite"
               label="Aanbieden ter review"
@@ -181,70 +179,77 @@ async function handleDelete() {
             />
             <Button
               v-if="isPendingReview && canApprove"
-              label="Afkeuren"
               danger
+              label="Afkeuren"
               @click="showRejectModal = true"
             />
-            <Button
-              v-if="isSuperUser"
-              label="Verwijderen"
-              danger
-              @click="handleDelete"
-            />
+            <Button v-if="isSuperUser" danger label="Verwijderen" @click="handleDelete" />
           </div>
-        </header>
-
-        <Alert v-if="actionError" :closeable="true" @close="actionError = null">
-          {{ actionError }}
-        </Alert>
-
-        <div class="space-y-8">
-          <section>
-            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
-              Details
-            </h4>
-            <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
-              <dt class="font-medium text-grey-700">Opsteller</dt>
-              <dd class="sm:col-span-2">{{ recovery.attribution.creatorName ?? '-' }}</dd>
-
-              <dt class="font-medium text-grey-700">Beoordelaar</dt>
-              <dd class="sm:col-span-2">{{ recovery.attribution.reviewerName ?? '-' }}</dd>
-
-              <dt class="font-medium text-grey-700">Uitvoerder</dt>
-              <dd class="sm:col-span-2">{{ recovery.attribution.contractorName ?? '-' }}</dd>
-
-              <dt v-if="recovery.note" class="font-medium text-grey-700">Notitie</dt>
-              <dd v-if="recovery.note" class="whitespace-pre-wrap sm:col-span-2">
-                {{ recovery.note }}
-              </dd>
-            </dl>
-          </section>
-
-          <section>
-            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-700">
-              Adressen ({{ samples.length }})
-            </h4>
-            <p v-if="samples.length === 0" class="text-sm text-grey-700">
-              Nog geen adressen toegevoegd.
-            </p>
-            <ul v-else class="divide-y divide-grey-200">
-              <li v-for="s in samples" :key="s.id" class="space-y-1 py-3 text-sm">
-                <p class="font-semibold text-grey-800">
-                  {{ formatAddress(addressStore.cache[s.building]) }}
-                </p>
-                <p class="text-xs text-grey-700">
-                  {{ recoveryTypeLabel(s.type) }}
-                  <template v-if="s.status !== null">
-                    · {{ recoveryStatusLabel(s.status) }}
-                  </template>
-                  <template v-if="s.recoveryDate">· {{ formatDate(s.recoveryDate) }}</template>
-                </p>
-                <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>
-              </li>
-            </ul>
-          </section>
         </div>
       </template>
+    </div>
+
+    <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">{{ error }}</Alert>
+    <Alert v-if="actionError" :closeable="true" class="mb-3" @close="actionError = null">
+      {{ actionError }}
+    </Alert>
+
+    <Card v-if="loading" class="flex justify-center py-8">
+      <Spinner />
+      <span v-if="false">{{ t('common.loading') }}</span>
+    </Card>
+
+    <Card v-else-if="recovery">
+      <div class="space-y-6">
+        <section>
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
+            Details
+          </h4>
+          <dl class="grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt class="text-grey-700">Opsteller</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.creatorName ?? '—' }}</dd>
+
+            <dt class="text-grey-700">Beoordelaar</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.reviewerName ?? '—' }}</dd>
+
+            <dt class="text-grey-700">Uitvoerder</dt>
+            <dd class="text-grey-800">{{ recovery.attribution.contractorName ?? '—' }}</dd>
+
+            <template v-if="recovery.note">
+              <dt class="text-grey-700">Notitie</dt>
+              <dd class="whitespace-pre-wrap text-grey-800">{{ recovery.note }}</dd>
+            </template>
+          </dl>
+        </section>
+
+        <section>
+          <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
+            Adressen ({{ samples.length }})
+          </h4>
+          <p v-if="samples.length === 0" class="text-sm text-grey-700">
+            Nog geen adressen toegevoegd.
+          </p>
+          <ul v-else class="overflow-hidden rounded-md border border-grey-200">
+            <li
+              v-for="s in samples"
+              :key="s.id"
+              class="space-y-1 border-b border-grey-200 px-3 py-3 text-sm last:border-b-0"
+            >
+              <p class="font-medium text-grey-800">
+                {{ formatAddress(addressStore.cache[s.building]) }}
+              </p>
+              <p class="text-xs text-grey-700">
+                {{ recoveryTypeLabel(s.type) }}
+                <template v-if="s.status !== null">
+                  · {{ recoveryStatusLabel(s.status) }}
+                </template>
+                <template v-if="s.recoveryDate">· {{ formatDate(s.recoveryDate) }}</template>
+              </p>
+              <p v-if="s.note" class="text-xs text-grey-700">{{ s.note }}</p>
+            </li>
+          </ul>
+        </section>
+      </div>
     </Card>
 
     <RejectModal v-if="showRejectModal" @close="showRejectModal = false" @submit="handleReject" />


### PR DESCRIPTION
## Summary

Picks up where PR #240 left off. The list views and primitives were already on the new shell, but the eight wizard screens still rendered their own legacy chrome — Card-wrapped titles, \`.List col-span-3 mt-16\` positioning that assumed a fixed top header, \`heading-3\` + negative-margin header tricks. This brings all of them onto the same vocabulary.

### Per-screen pattern now

- Plain page header in the main column: small back-link, page title (\`text-xl font-semibold\`), subtitle, and any header-level action buttons.
- New \`Common/WizardSteps.vue\` step indicator under the header — numbered circles, active step in the brand green.
- Content sits in one or more flat \`Card\`s; section headers are \`text-xs uppercase tracking-wide\`.

### Screens touched

| Screen | Notable changes |
|---|---|
| \`InquiryStep1\` / \`RecoveryStep1\` | Two-column field grid, new section dividers, form footer with one primary action |
| \`InquiryStep2\` / \`RecoveryStep2\` | 1+2 grid: address-picker panel on the left (\`!p-0\` Card with internal header + hover row), sample form on the right |
| \`InquiryStep3\` / \`RecoveryStep3\` | Review screen; empty-address state is now a warning **Alert** instead of red prose |
| \`InquiryView\` / \`RecoveryView\` | Status badge sits beside the title; action buttons use the new outline / danger variants |

### Scope

Touched **only** \`<template>\` blocks and added the \`WizardSteps\` + \`RouterLink\` imports where missing. Script logic, validation, API calls, and the inner \`SampleForm\` / \`AddressPicker\` components are unchanged.

## Test plan
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` on touched files — clean
- [x] \`pnpm build\` — clean
- [x] Dev server boots; root HTTP 200
- [ ] **Manual:**
  - Click **Nieuwe rapportage** from the inquiry list → land on Step 1; back link + step indicator visible; form looks like one Card with sectioned content.
  - Step 1 → save and continue → Step 2 shows the new 1+2 grid; address list with hover highlight; sample form on the right.
  - Step 3 review screen: details \`dl\` reads cleanly; empty-addresses state shows the new warning Alert.
  - Sign in as approver, open a pending-review inquiry: **Goedkeuren** / **Afkeuren** buttons render; RejectModal still opens centered.
  - Recovery side: same checks (Step 1 / Step 2 / Step 3 / View).

🤖 Generated with [Claude Code](https://claude.com/claude-code)