### PR TITLE
fix(ui): bump page padding + wizard typography + button sizes

### DIFF
--- a/src/components/Common/WizardSteps.vue
+++ b/src/components/Common/WizardSteps.vue
@@ -9,14 +9,14 @@ withDefaults(
 </script>
 
 <template>
-  <ol class="flex flex-wrap items-center gap-2 text-sm">
+  <ol class="flex flex-wrap items-center gap-3 text-sm">
     <template v-for="(label, idx) in steps" :key="idx">
-      <li class="flex items-center gap-2">
+      <li class="flex items-center gap-2.5">
         <span
-          class="inline-flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold"
+          class="inline-flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold transition-colors"
           :class="
             idx + 1 === current
-              ? 'border-green-500 bg-green-500 text-white'
+              ? 'border-green-500 bg-green-500 text-white shadow-sm'
               : idx + 1 < current
                 ? 'border-green-500 bg-green-50 text-green-700'
                 : 'border-grey-200 bg-white text-grey-700'
@@ -25,7 +25,7 @@ withDefaults(
           {{ idx + 1 }}
         </span>
         <span
-          class="font-medium"
+          class="text-sm font-medium"
           :class="idx + 1 === current ? 'text-grey-800' : 'text-grey-700'"
         >
           {{ label }}
@@ -33,11 +33,10 @@ withDefaults(
       </li>
       <li
         v-if="idx < steps.length - 1"
-        class="text-grey-400"
+        class="h-px w-10 transition-colors"
+        :class="idx + 1 < current ? 'bg-green-500' : 'bg-grey-200'"
         aria-hidden="true"
-      >
-        ›
-      </li>
+      />
     </template>
   </ol>
 </template>

--- a/src/components/Layout/MainWrapper.vue
+++ b/src/components/Layout/MainWrapper.vue
@@ -5,7 +5,7 @@ import Sidebar from '@/components/Layout/Sidebar.vue'
 <template>
   <div class="min-h-screen bg-grey-100">
     <Sidebar />
-    <main class="ml-56 min-h-screen p-6">
+    <main class="ml-56 min-h-screen p-8">
       <slot />
     </main>
   </div>

--- a/src/views/inquiry/InquiryStep1.vue
+++ b/src/views/inquiry/InquiryStep1.vue
@@ -179,7 +179,7 @@ onBeforeMount(async () => {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'inquiry-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -188,7 +188,7 @@ onBeforeMount(async () => {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">
+          <h2 class="text-2xl font-semibold text-grey-800">
             {{ isNew ? 'Nieuwe rapportage' : 'Rapportage bewerken' }}
           </h2>
           <p class="mt-0.5 text-sm text-grey-700">
@@ -214,7 +214,7 @@ onBeforeMount(async () => {
           <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Rapport
           </h4>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="grid grid-cols-1 gap-5 md:grid-cols-2">
             <Input
               v-model="formData.documentName"
               label="Naam"
@@ -308,8 +308,9 @@ onBeforeMount(async () => {
           <Textarea v-model="formData.note" placeholder="Optionele notitie…" :rows="4" />
         </section>
 
-        <div class="flex justify-end gap-2 border-t border-grey-200 pt-4">
+        <div class="flex justify-end gap-2 border-t border-grey-200 pt-6">
           <Button
+            lg
             label="Opslaan en verder"
             type="submit"
             :disabled="saving || uploading"

--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -203,7 +203,7 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'inquiry-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -212,14 +212,14 @@ function previous() {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">Adressen</h2>
+          <h2 class="text-2xl font-semibold text-grey-800">Adressen</h2>
           <p class="mt-0.5 text-sm text-grey-700">
             Zoek adressen en vul per locatie de bevindingen in.
           </p>
         </div>
         <div class="flex gap-2">
-          <Button outline label="Vorige" @click="previous" />
-          <Button label="Volgende" @click="next" />
+          <Button lg outline label="Vorige" @click="previous" />
+          <Button lg label="Volgende" @click="next" />
         </div>
       </div>
       <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="2" />

--- a/src/views/inquiry/InquiryStep3.vue
+++ b/src/views/inquiry/InquiryStep3.vue
@@ -85,7 +85,7 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'inquiry-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -94,7 +94,7 @@ function previous() {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">Controle</h2>
+          <h2 class="text-2xl font-semibold text-grey-800">Controle</h2>
           <p v-if="inquiry" class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
             <span>{{ inquiryTypeLabel(inquiry.type) }}</span>
             <span aria-hidden="true">·</span>
@@ -103,8 +103,9 @@ function previous() {
           </p>
         </div>
         <div class="flex gap-2">
-          <Button outline label="Vorige" @click="previous" />
+          <Button lg outline label="Vorige" @click="previous" />
           <Button
+            lg
             label="Aanbieden ter review"
             :disabled="!canSubmit || submitting"
             @click="submit"

--- a/src/views/inquiry/InquiryView.vue
+++ b/src/views/inquiry/InquiryView.vue
@@ -140,7 +140,7 @@ async function handleDelete() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'inquiry-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -152,7 +152,7 @@ async function handleDelete() {
         <div class="flex flex-wrap items-end justify-between gap-3">
           <div>
             <div class="flex flex-wrap items-center gap-2">
-              <h2 class="text-xl font-semibold text-grey-800">{{ inquiry.documentName }}</h2>
+              <h2 class="text-2xl font-semibold text-grey-800">{{ inquiry.documentName }}</h2>
               <StatusBadge :status="inquiry.state.auditStatus" />
             </div>
             <p class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
@@ -166,11 +166,13 @@ async function handleDelete() {
             <Button v-if="isEditable && canWrite" outline label="Bewerken" @click="goEdit" />
             <Button
               v-if="canSubmitForReview && canWrite"
+              lg
               label="Aanbieden ter review"
               @click="handleSubmitForReview"
             />
             <Button
               v-if="isPendingReview && canApprove"
+              lg
               label="Goedkeuren"
               @click="handleApprove"
             />

--- a/src/views/recovery/RecoveryStep1.vue
+++ b/src/views/recovery/RecoveryStep1.vue
@@ -162,7 +162,7 @@ onBeforeMount(async () => {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'recovery-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -171,7 +171,7 @@ onBeforeMount(async () => {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">
+          <h2 class="text-2xl font-semibold text-grey-800">
             {{ isNew ? 'Nieuw herstel' : 'Herstel bewerken' }}
           </h2>
           <p class="mt-0.5 text-sm text-grey-700">
@@ -197,7 +197,7 @@ onBeforeMount(async () => {
           <h4 class="mb-3 text-xs font-semibold uppercase tracking-wide text-grey-700">
             Document
           </h4>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="grid grid-cols-1 gap-5 md:grid-cols-2">
             <Input
               v-model="formData.documentName"
               label="Naam"
@@ -279,8 +279,9 @@ onBeforeMount(async () => {
           <Textarea v-model="formData.note" placeholder="Optionele notitie…" :rows="4" />
         </section>
 
-        <div class="flex justify-end gap-2 border-t border-grey-200 pt-4">
+        <div class="flex justify-end gap-2 border-t border-grey-200 pt-6">
           <Button
+            lg
             label="Opslaan en verder"
             type="submit"
             :disabled="saving || uploading"

--- a/src/views/recovery/RecoveryStep2.vue
+++ b/src/views/recovery/RecoveryStep2.vue
@@ -157,7 +157,7 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'recovery-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -166,14 +166,14 @@ function previous() {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">Adressen</h2>
+          <h2 class="text-2xl font-semibold text-grey-800">Adressen</h2>
           <p class="mt-0.5 text-sm text-grey-700">
             Zoek adressen en vul per locatie de herstel-gegevens in.
           </p>
         </div>
         <div class="flex gap-2">
-          <Button outline label="Vorige" @click="previous" />
-          <Button label="Volgende" @click="next" />
+          <Button lg outline label="Vorige" @click="previous" />
+          <Button lg label="Volgende" @click="next" />
         </div>
       </div>
       <WizardSteps :steps="['Gegevens', 'Adressen', 'Controle']" :current="2" />

--- a/src/views/recovery/RecoveryStep3.vue
+++ b/src/views/recovery/RecoveryStep3.vue
@@ -85,7 +85,7 @@ function previous() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'recovery-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -94,7 +94,7 @@ function previous() {
       </RouterLink>
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 class="text-xl font-semibold text-grey-800">Controle</h2>
+          <h2 class="text-2xl font-semibold text-grey-800">Controle</h2>
           <p v-if="recovery" class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
             <span>{{ recoveryDocumentTypeLabel(recovery.type) }}</span>
             <span aria-hidden="true">·</span>
@@ -103,8 +103,9 @@ function previous() {
           </p>
         </div>
         <div class="flex gap-2">
-          <Button outline label="Vorige" @click="previous" />
+          <Button lg outline label="Vorige" @click="previous" />
           <Button
+            lg
             label="Aanbieden ter review"
             :disabled="!canSubmit || submitting"
             @click="submit"

--- a/src/views/recovery/RecoveryView.vue
+++ b/src/views/recovery/RecoveryView.vue
@@ -143,7 +143,7 @@ async function handleDelete() {
 
 <template>
   <MainWrapper>
-    <div class="mb-5 space-y-3">
+    <div class="mb-8 space-y-3">
       <RouterLink
         :to="{ name: 'recovery-list' }"
         class="inline-flex items-center gap-1 text-xs font-medium text-grey-700 hover:text-grey-800"
@@ -155,7 +155,7 @@ async function handleDelete() {
         <div class="flex flex-wrap items-end justify-between gap-3">
           <div>
             <div class="flex flex-wrap items-center gap-2">
-              <h2 class="text-xl font-semibold text-grey-800">{{ recovery.documentName }}</h2>
+              <h2 class="text-2xl font-semibold text-grey-800">{{ recovery.documentName }}</h2>
               <StatusBadge :status="recovery.state.auditStatus" />
             </div>
             <p class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-grey-700">
@@ -169,11 +169,13 @@ async function handleDelete() {
             <Button v-if="isEditable && canWrite" outline label="Bewerken" @click="goEdit" />
             <Button
               v-if="canSubmitForReview && canWrite"
+              lg
               label="Aanbieden ter review"
               @click="handleSubmitForReview"
             />
             <Button
               v-if="isPendingReview && canApprove"
+              lg
               label="Goedkeuren"
               @click="handleApprove"
             />


### PR DESCRIPTION
## Summary

Your "not coming together like a real app — button size, paddings, margins" feedback. Concrete moves:

### Page chrome
- \`MainWrapper\` page padding \`p-6\` → \`p-8\`. Lists and wizards alike get more room around the content. The list views still look right; the wizards stop feeling crammed against the sidebar.
- Wizard page title \`text-xl\` → \`text-2xl\`. The wizard is the primary task, not an admin list, so the title carries the weight.
- Header-to-content gap \`mb-5\` → \`mb-8\`.
- Step 1 form footer divider \`pt-4\` → \`pt-6\` so the submit button isn't pressed against the line.
- Step 1 field grid \`gap-4\` → \`gap-5\`.

### Button sizes (using the existing \`lg\` variant)
- **Opslaan en verder** (Step 1)
- **Vorige** / **Volgende** (Step 2 + 3)
- **Aanbieden ter review** (Step 3)
- **Aanbieden ter review** / **Goedkeuren** on the View pages

Secondary actions (\`Document\`, \`Bewerken\`, \`Afkeuren\`, \`Verwijderen\`) stay default size — the row stays scannable instead of going chunky.

### WizardSteps redesign
Connecting rail between the numbered nodes (grey by default, green when the step is past), \`h-7 w-7\` instead of \`h-6 w-6\`, subtle shadow on the active node. Reads as one continuous control instead of three loose pills.

## Test plan
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` on touched files — clean
- [x] \`pnpm build\` — clean
- [x] Dev server boots; root HTTP 200
- [ ] **Manual:** start a new inquiry → Step 1's submit button looks like a real primary CTA; Step 2's Vorige/Volgende are visually weighty; the step indicator rail at the top of the wizard ties the three steps together. Same for the recovery flow. View pages: Aanbieden ter review / Goedkeuren stand out without crowding the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)