### PR TITLE
feat(inquiry): show selected samples on a map in Step 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 VITE_FUNDERMAPS_URL=https://fundermaps-api-test-grcaa.ondigitalocean.app
+
+# Optional. Set both to enable Step 2's sample map column.
+# Without them the wizard still works; the map column is hidden.
+# VITE_MAPBOX_TOKEN=pk....
+# VITE_MAPBOX_STYLE=mapbox://styles/mapbox/streets-v12

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,20 +2,12 @@
 
 interface ImportMetaEnv {
   readonly VITE_FUNDERMAPS_URL: string
+  // Optional — when both are set, Step 2's sample map column renders.
+  // Without them the wizard still works; the map column is hidden.
+  readonly VITE_MAPBOX_TOKEN?: string
+  readonly VITE_MAPBOX_STYLE?: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
-
-/**
- * @bhplugin/vue3-datatable ships types but its package.json `exports` field
- * doesn't surface them under the resolver vite-tsc uses. Re-declare as
- * a minimal Vue component shim until upstream fixes its exports map.
- */
-declare module '@bhplugin/vue3-datatable' {
-  import type { DefineComponent } from 'vue'
-  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>
-  export default component
-}
-

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@vueuse/core": "^14.3.0",
     "lodash-es": "^4.17.21",
+    "mapbox-gl": "^3.23.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.34",
     "vue-i18n": "^11.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.18.1
+      mapbox-gl:
+        specifier: ^3.23.1
+        version: 3.24.0
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
@@ -221,6 +224,21 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mapbox/mapbox-gl-supported@3.0.0':
+    resolution: {integrity: sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -523,6 +541,12 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
@@ -537,6 +561,12 @@ packages:
 
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
+
+  '@types/pbf@3.0.5':
+    resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -765,6 +795,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  cheap-ruler@4.0.0:
+    resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -809,6 +842,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  csscolorparser@1.0.3:
+    resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -849,6 +885,9 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -1000,6 +1039,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  geojson-vt@4.0.3:
+    resolution: {integrity: sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1082,6 +1127,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1178,6 +1226,12 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mapbox-gl@3.24.0:
+    resolution: {integrity: sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA==}
+
+  martinez-polygon-clipping@0.8.1:
+    resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
+
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -1211,6 +1265,9 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1261,6 +1318,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -1305,6 +1366,9 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1374,6 +1438,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1383,6 +1450,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
@@ -1396,12 +1466,18 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  robust-predicates@2.0.4:
+    resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
 
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
@@ -1560,6 +1636,12 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  splaytree@0.1.4:
+    resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -1595,6 +1677,9 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1912,6 +1997,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/mapbox-gl-supported@3.0.0': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.5':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -2126,6 +2225,12 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
+
   '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2139,6 +2244,12 @@ snapshots:
   '@types/node@24.12.3':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/pbf@3.0.5': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -2439,6 +2550,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  cheap-ruler@4.0.0: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -2487,6 +2600,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  csscolorparser@1.0.3: {}
+
   cssesc@3.0.0: {}
 
   csso@5.0.5:
@@ -2520,6 +2635,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  earcut@3.0.2: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -2675,6 +2792,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  geojson-vt@4.0.3: {}
+
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2726,6 +2847,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2805,6 +2928,37 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mapbox-gl@3.24.0:
+    dependencies:
+      '@mapbox/mapbox-gl-supported': 3.0.0
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
+      '@types/pbf': 3.0.5
+      '@types/supercluster': 7.1.3
+      cheap-ruler: 4.0.0
+      csscolorparser: 1.0.3
+      earcut: 3.0.2
+      geojson-vt: 4.0.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      martinez-polygon-clipping: 0.8.1
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
+  martinez-polygon-clipping@0.8.1:
+    dependencies:
+      robust-predicates: 2.0.4
+      splaytree: 0.1.4
+      tinyqueue: 3.0.0
+
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
@@ -2834,6 +2988,8 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.12: {}
 
@@ -2884,6 +3040,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.1.0: {}
@@ -2926,6 +3086,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -2938,11 +3100,15 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  protocol-buffers-schema@3.6.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   read-package-json-fast@4.0.0:
     dependencies:
@@ -2954,9 +3120,15 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  robust-predicates@2.0.4: {}
 
   rolldown@1.0.2:
     dependencies:
@@ -3103,6 +3275,12 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  splaytree@0.1.4: {}
+
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.1.0
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
@@ -3142,6 +3320,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyqueue@3.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/components/Mapbox/SampleMap.vue
+++ b/src/components/Mapbox/SampleMap.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, shallowRef, useTemplateRef, watch } from 'vue'
+import mapboxgl, { type Map as MapboxMap, type Marker } from 'mapbox-gl'
+import 'mapbox-gl/dist/mapbox-gl.css'
+
+export interface SamplePin {
+  id: string | number
+  lng: number
+  lat: number
+}
+
+const props = withDefaults(
+  defineProps<{
+    pins: SamplePin[]
+    selectedId?: string | number | null
+    /** Zoom level used when there's exactly one pin to fit. Multi-pin sets use fitBounds. */
+    singlePinZoom?: number
+  }>(),
+  { selectedId: null, singlePinZoom: 17 },
+)
+
+const emit = defineEmits<{ select: [id: string | number] }>()
+
+const container = useTemplateRef<HTMLElement>('container')
+const mapInstance = shallowRef<MapboxMap | null>(null)
+// Marker per pin id. Selection state is reflected on the existing element
+// instead of rebuilding markers — avoids a flicker on every click.
+const markerById = new Map<string | number, { marker: Marker; el: HTMLElement }>()
+
+// Centroid of NL — used as the initial center when the map mounts before any
+// pins exist. The first pins-change fitBounds immediately repositions, so the
+// user never actually sees this view.
+const FALLBACK_CENTER: [number, number] = [4.897, 52.378]
+
+// Falsy token / style → no map. Caller hides the component or accepts a blank
+// container; either way the rest of the wizard keeps working.
+const token = import.meta.env.VITE_MAPBOX_TOKEN
+const style = import.meta.env.VITE_MAPBOX_STYLE
+
+function makePinEl(id: string | number): HTMLElement {
+  const el = document.createElement('div')
+  el.className = 'sample-pin'
+  el.setAttribute('data-selected', String(id === props.selectedId))
+  el.addEventListener('click', () => emit('select', id))
+  return el
+}
+
+function rebuildMarkers(): void {
+  const map = mapInstance.value
+  if (!map) return
+
+  const wanted = new Set(props.pins.map((p) => p.id))
+
+  // Remove markers no longer in the pins list.
+  for (const [id, entry] of markerById) {
+    if (!wanted.has(id)) {
+      entry.marker.remove()
+      markerById.delete(id)
+    }
+  }
+
+  // Add or move markers for the current pins.
+  for (const pin of props.pins) {
+    const existing = markerById.get(pin.id)
+    if (existing) {
+      existing.marker.setLngLat([pin.lng, pin.lat])
+    } else {
+      const el = makePinEl(pin.id)
+      const marker = new mapboxgl.Marker({ element: el }).setLngLat([pin.lng, pin.lat]).addTo(map)
+      markerById.set(pin.id, { marker, el })
+    }
+  }
+}
+
+function updateSelection(): void {
+  for (const [id, { el }] of markerById) {
+    el.setAttribute('data-selected', String(id === props.selectedId))
+  }
+}
+
+// Frame the visible pins. One pin → fly to it; many → fit a bounding box with
+// padding so the selected one isn't pressed against the edge.
+function frame(): void {
+  const map = mapInstance.value
+  if (!map || !props.pins.length) return
+
+  if (props.pins.length === 1) {
+    const p = props.pins[0]
+    map.flyTo({ center: [p.lng, p.lat], zoom: props.singlePinZoom, essential: true })
+    return
+  }
+
+  const bounds = new mapboxgl.LngLatBounds()
+  for (const p of props.pins) bounds.extend([p.lng, p.lat])
+  map.fitBounds(bounds, { padding: 60, maxZoom: 18, duration: 400 })
+}
+
+onMounted(() => {
+  if (!container.value || !token || !style) return
+  mapboxgl.accessToken = token
+
+  const initial = props.pins[0]
+  const map = new mapboxgl.Map({
+    container: container.value,
+    style,
+    center: initial ? [initial.lng, initial.lat] : FALLBACK_CENTER,
+    zoom: initial ? props.singlePinZoom : 8,
+    attributionControl: false,
+  })
+
+  map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right')
+
+  map.on('load', () => {
+    mapInstance.value = map
+    rebuildMarkers()
+    frame()
+  })
+})
+
+onBeforeUnmount(() => {
+  for (const { marker } of markerById.values()) marker.remove()
+  markerById.clear()
+  mapInstance.value?.remove()
+  mapInstance.value = null
+})
+
+watch(
+  () => props.pins,
+  () => {
+    rebuildMarkers()
+    frame()
+  },
+  { deep: true },
+)
+
+watch(() => props.selectedId, updateSelection)
+</script>
+
+<template>
+  <div v-if="token && style" ref="container" class="h-full w-full"></div>
+  <div
+    v-else
+    class="flex h-full w-full items-center justify-center rounded-md border border-grey-200 bg-grey-100 text-xs text-grey-700"
+  >
+    Kaart niet beschikbaar (geen Mapbox-token geconfigureerd).
+  </div>
+</template>
+
+<style scoped>
+:deep(.sample-pin) {
+  width: 16px;
+  height: 16px;
+  border-radius: 9999px;
+  background: var(--color-grey-400);
+  border: 2px solid white;
+  box-shadow: 0 0 0 1px var(--color-grey-400);
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+:deep(.sample-pin:hover) {
+  background: var(--color-grey-800);
+  box-shadow: 0 0 0 1px var(--color-grey-800);
+}
+
+:deep(.sample-pin[data-selected="true"]) {
+  background: var(--color-green-500);
+  box-shadow:
+    0 0 0 2px var(--color-green-500),
+    0 4px 8px rgb(0 0 0 / 0.15);
+  transform: scale(1.25);
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,14 +11,17 @@ import Logout from '@/views/auth/Logout.vue'
 import NotFound from '@/views/auth/NotFound.vue'
 import InquiryList from '@/views/InquiryListView.vue'
 import InquiryStep1 from '@/views/inquiry/InquiryStep1.vue'
-import InquiryStep2 from '@/views/inquiry/InquiryStep2.vue'
 import InquiryStep3 from '@/views/inquiry/InquiryStep3.vue'
 import InquiryView from '@/views/inquiry/InquiryView.vue'
 import RecoveryList from '@/views/RecoveryListView.vue'
 import RecoveryStep1 from '@/views/recovery/RecoveryStep1.vue'
-import RecoveryStep2 from '@/views/recovery/RecoveryStep2.vue'
 import RecoveryStep3 from '@/views/recovery/RecoveryStep3.vue'
 import RecoveryView from '@/views/recovery/RecoveryView.vue'
+
+// Step 2 pulls in mapbox-gl (~250 KB gzip) for the sample map. Lazy-load
+// so the list views, Step 1, Step 3, and View pages stay light.
+const InquiryStep2 = () => import('@/views/inquiry/InquiryStep2.vue')
+const RecoveryStep2 = () => import('@/views/recovery/RecoveryStep2.vue')
 
 const routes: RouteRecordRaw[] = [
   // Login lives in the auth app. Redirect to OIDC in beforeEnter — before the

--- a/src/services/fundermaps/interfaces/IAddress.ts
+++ b/src/services/fundermaps/interfaces/IAddress.ts
@@ -5,6 +5,10 @@
  * `id` is the internal `gfm-` identifier. `external_id` is the BAG
  * NUMMERAANDUIDING. `building_id` is the BAG PAND id (used for sample
  * creation — the sample resolves to its building via this).
+ *
+ * `latitude` / `longitude` are the centroid of the linked building
+ * footprint (WGS84). Both are null when the building row is missing
+ * or has no geometry — render without a marker, not as 404.
  */
 
 export interface IAddress {
@@ -15,4 +19,6 @@ export interface IAddress {
   street: string | null
   city: string | null
   building_id: string
+  latitude: number | null
+  longitude: number | null
 }

--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -11,6 +11,7 @@ import AddressPicker from '@/components/Inquiry/AddressPicker.vue'
 import SampleForm from '@/components/Inquiry/SampleForm.vue'
 import Spinner from '@/components/Common/Spinner.vue'
 import WizardSteps from '@/components/Common/WizardSteps.vue'
+import SampleMap, { type SamplePin } from '@/components/Mapbox/SampleMap.vue'
 import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
@@ -35,6 +36,25 @@ const actionError: Ref<string | null> = ref(null)
 
 const selectedId = ref<number | null>(null)
 const selected = computed(() => samples.value.find((s) => s.id === selectedId.value) ?? null)
+
+// Map markers — one per sample whose address has resolved coordinates.
+// `latitude` / `longitude` come back null from the geocoder when the
+// linked building has no geometry; those samples simply don't render a
+// pin (the list + form still work).
+const mapPins = computed<SamplePin[]>(() => {
+  const out: SamplePin[] = []
+  for (const s of samples.value) {
+    const a = addressStore.cache[s.address]
+    if (a && a.latitude != null && a.longitude != null) {
+      out.push({ id: s.id, lat: a.latitude, lng: a.longitude })
+    }
+  }
+  return out
+})
+
+function handleMapSelect(id: string | number): void {
+  if (typeof id === 'number') selectSample(id)
+}
 
 async function load() {
   try {
@@ -270,7 +290,11 @@ function previous() {
         </p>
       </Card>
 
-      <div class="lg:col-span-2">
+      <div class="space-y-4 lg:col-span-2">
+        <Card v-if="mapPins.length" class="h-64 overflow-hidden !p-0">
+          <SampleMap :pins="mapPins" :selected-id="selectedId" @select="handleMapSelect" />
+        </Card>
+
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
         </Card>


### PR DESCRIPTION
## Summary

Spatial-context foundation for the inquiry wizard. Staff now see their inquiry's samples plotted on a Mapbox map above the sample form in Step 2 — confirms "is this the right building?" while filling the deep foundation form, and gives a spatial sense of where the samples in a single inquiry sit relative to each other.

Intentional intermediate state. The map sits in the right column above the sample form (**Option A** from the design sketch); a follow-up PR upgrades to the full **three-column layout (Option B)** and mirrors onto the recovery wizard.

### What's in this PR

- **New \`Common/Mapbox/SampleMap.vue\`** (~140 LOC): wraps \`mapbox-gl\`, takes \`pins\` / \`selectedId\`, emits \`select\`. Diffs markers by id so selection changes don't tear down/rebuild — just flip \`data-selected\` on the existing element. \`fitBounds\` for multi-pin, \`flyTo\` for single-pin. Renders a friendly fallback (*"Kaart niet beschikbaar — geen Mapbox-token"*) when the env vars are missing.
- **\`mapbox-gl ^3.23.1\`** — matches FunderMapsWebFront so the fleet stays on one version.
- **New optional env vars \`VITE_MAPBOX_TOKEN\` + \`VITE_MAPBOX_STYLE\`**. Both absent → wizard still works, map column is just blank.
- **\`IAddress\`** carries \`latitude\` / \`longitude\` (centroid of the building footprint, WGS84) — populated by FunderMapsApi#62.
- **\`InquiryStep2\`** derives map pins from \`samples\` + \`addressStore\`. Samples whose address lacks coordinates simply don't render a pin; the list + form still work.
- **Step 2 routes lazy-loaded** so the mapbox-gl payload doesn't ship to users who never enter the wizard.

### Bundle impact
| | raw | gzip |
|---|---|---|
| Pre-change (one chunk) | 2.16 MB | 603 KB |
| Post-change main chunk | 357 KB | 113 KB |
| Post-change Step 2 chunk (only on Step 2 entry) | 1.79 MB | 487 KB |

## Test plan
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` on touched files — clean
- [x] \`pnpm build\` — clean (chunk-size warning expected from mapbox-gl)
- [x] Dev server boots; root HTTP 200
- [x] API#62 deployed; centroid is in the wire format
- [ ] **Manual:** open an inquiry → Step 2. Confirm:
  - Map appears above the sample form when there's a selected sample
  - Selected sample's pin is green, others grey
  - Clicking a pin selects that sample (same as clicking the address in the left list)
  - Pin colors update on selection without flicker (markers are diffed, not rebuilt)
  - Adding a new address → its pin appears + map re-fits bounds
  - With \`VITE_MAPBOX_TOKEN\` unset: card shows the fallback message, rest of Step 2 still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)