### PR TITLE
fix(map): make SampleMap actually render (zero-height container)

### DIFF
--- a/src/components/Mapbox/SampleMap.vue
+++ b/src/components/Mapbox/SampleMap.vue
@@ -112,6 +112,11 @@ onMounted(() => {
 
   map.on('load', () => {
     mapInstance.value = map
+    // Force a resize on the next frame in case the container's final
+    // dimensions weren't known when mapbox-gl read them at init (lazy
+    // mount, transition, parent that resolves height after layout).
+    // Cheap and idempotent; protects against a silent 0x0 render.
+    requestAnimationFrame(() => map.resize())
     rebuildMarkers()
     frame()
   })

--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -291,9 +291,16 @@ function previous() {
       </Card>
 
       <div class="space-y-4 lg:col-span-2">
-        <Card v-if="mapPins.length" class="h-64 overflow-hidden !p-0">
+        <!-- Bordered div, not <Card> — Card's body div has auto height, so a
+             child with `h-full` collapses to 0 and Mapbox renders a 0x0 canvas
+             with no error. Putting the explicit `h-64` on the direct parent
+             of SampleMap gives mapbox-gl the dimensions it needs at init. -->
+        <div
+          v-if="mapPins.length"
+          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white"
+        >
           <SampleMap :pins="mapPins" :selected-id="selectedId" @select="handleMapSelect" />
-        </Card>
+        </div>
 
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>


### PR DESCRIPTION
## Summary

PR #243 deployed but the map stayed invisible — no error, no canvas. Diagnosis: zero-height container. Two fixes:

### 1. Card body doesn't propagate explicit height
\`<Card class="h-64 !p-0">\` put \`h-64\` on the Card's outer div, but Card's body div (\`card__content\`) is auto-height — so \`SampleMap\`'s \`h-full\` resolved against an auto-height parent and collapsed to 0. Mapbox initialised a 0×0 canvas; nothing rendered, nothing threw.

Fix: drop the \`<Card>\` wrapper and use a plain bordered div with \`h-64\` on the *direct parent* of \`SampleMap\`. The map's \`h-full\` now resolves against a known 256px and the canvas comes up at the right size.

\`\`\`diff
-<Card v-if="mapPins.length" class="h-64 overflow-hidden !p-0">
-  <SampleMap ... />
-</Card>
+<div v-if="mapPins.length" class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white">
+  <SampleMap ... />
+</div>
\`\`\`

### 2. Defensive resize after load
mapbox-gl reads the container's dimensions at init. If the container's final size isn't known yet (lazy mount, transition, parent layout that settles late), the map stays sized at the init-time value forever — including 0×0.

Fix: \`requestAnimationFrame(() => map.resize())\` after \`map.on('load')\`. Cheap, idempotent, protects against the same silent-0×0 trap if a future consumer puts the map in a flex container or any context where the height resolves after first layout.

## Test plan
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` on touched files — clean
- [x] \`pnpm build\` — clean
- [ ] **Manual:** open an inquiry → Step 2. Map renders at 256px tall, pins visible, click-to-select sync still works. With dev tools open: container div reports \`height: 256px\`, mapbox canvas matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)