### PR TITLE
feat(list): search the full dataset via API ?q=

### DIFF
--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -31,7 +31,7 @@
       "title": "Rapportages",
       "subtitle": "Beheer je rapportages en hun status.",
       "newButton": "Nieuwe rapportage",
-      "searchPlaceholder": "Zoek op naam, type, opsteller…",
+      "searchPlaceholder": "Zoek op id, naam, adres of BAG…",
       "empty": "Geen rapportages gevonden.",
       "col": {
         "documentName": "Naam",
@@ -51,7 +51,7 @@
       "title": "Herstel",
       "subtitle": "Beheer funderingsherstel-dossiers en hun status.",
       "newButton": "Nieuw herstel",
-      "searchPlaceholder": "Zoek op naam, type, opsteller…",
+      "searchPlaceholder": "Zoek op id, naam of BAG…",
       "empty": "Geen herstel-dossiers gevonden.",
       "col": {
         "documentName": "Naam",

--- a/src/services/fundermaps/endpoints/inquiry.ts
+++ b/src/services/fundermaps/endpoints/inquiry.ts
@@ -10,10 +10,11 @@ interface IDownloadInfo {
   accessLink: string
 }
 
-export async function list(opts: { limit?: number; offset?: number } = {}) {
+export async function list(opts: { limit?: number; offset?: number; q?: string } = {}) {
   const queryString: Record<string, string> = {}
   if (opts.limit != null) queryString.limit = String(opts.limit)
   if (opts.offset != null) queryString.offset = String(opts.offset)
+  if (opts.q) queryString.q = opts.q
   return (await get({ endpoint: '/inquiry', queryString })) as IInquiry[]
 }
 

--- a/src/services/fundermaps/endpoints/recovery.ts
+++ b/src/services/fundermaps/endpoints/recovery.ts
@@ -10,10 +10,11 @@ interface IDownloadInfo {
   accessLink: string
 }
 
-export async function list(opts: { limit?: number; offset?: number } = {}) {
+export async function list(opts: { limit?: number; offset?: number; q?: string } = {}) {
   const queryString: Record<string, string> = {}
   if (opts.limit != null) queryString.limit = String(opts.limit)
   if (opts.offset != null) queryString.offset = String(opts.offset)
+  if (opts.q) queryString.q = opts.q
   return (await get({ endpoint: '/recovery', queryString })) as IRecovery[]
 }
 

--- a/src/views/InquiryListView.vue
+++ b/src/views/InquiryListView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, type Ref } from 'vue'
+import { onBeforeMount, ref, watch, type Ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { refDebounced } from '@vueuse/core'
 
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
@@ -22,6 +23,7 @@ const router = useRouter()
 const loading = ref(true)
 const error: Ref<string | null> = ref(null)
 const search = ref('')
+const debouncedSearch = refDebounced(search, 300)
 const rows: Ref<IInquiry[]> = ref([])
 
 const columns = [
@@ -34,29 +36,14 @@ const columns = [
   { field: 'status', title: t('inquiry.list.col.status'), width: '11rem' },
 ]
 
-const filteredRows = computed(() => {
-  const q = search.value.trim().toLowerCase()
-  if (!q) return rows.value
-  return rows.value.filter((r) => {
-    const docName = (r.documentName ?? '').toLowerCase()
-    const creator = (r.attribution?.creatorName ?? '').toLowerCase()
-    const reviewer = (r.attribution?.reviewerName ?? '').toLowerCase()
-    const typeLabel = inquiryTypeLabel(r.type).toLowerCase()
-    return (
-      String(r.id).includes(q) ||
-      docName.includes(q) ||
-      typeLabel.includes(q) ||
-      creator.includes(q) ||
-      reviewer.includes(q)
-    )
-  })
-})
-
-async function load() {
+async function load(query: string) {
   try {
     loading.value = true
     error.value = null
-    rows.value = await api.inquiry.list({ limit: 200 })
+    const q = query.trim()
+    // Bare browse: most-recent slice. Search: server-side across the full
+    // dataset (id / document_name / sample address / BAG identifiers).
+    rows.value = q ? await api.inquiry.list({ q }) : await api.inquiry.list({ limit: 200 })
   } catch (e) {
     error.value = getErrorMessage(e) ?? t('error.generic')
   } finally {
@@ -64,7 +51,8 @@ async function load() {
   }
 }
 
-onBeforeMount(load)
+onBeforeMount(() => load(''))
+watch(debouncedSearch, (q) => load(q))
 
 function handleSelect(row: IInquiry) {
   router.push({ name: 'inquiry-view', params: { id: row.id } })
@@ -94,7 +82,7 @@ function newInquiry() {
           :placeholder="t('inquiry.list.searchPlaceholder')"
         />
       </div>
-      <span class="text-xs text-grey-700">{{ filteredRows.length }} / {{ rows.length }}</span>
+      <span class="text-xs text-grey-700">{{ rows.length }}</span>
     </div>
 
     <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">
@@ -102,7 +90,7 @@ function newInquiry() {
     </Alert>
 
     <Table
-      :rows="filteredRows"
+      :rows="rows"
       :columns="columns"
       :loading="loading"
       :emptyMessage="t('inquiry.list.empty')"

--- a/src/views/RecoveryListView.vue
+++ b/src/views/RecoveryListView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, type Ref } from 'vue'
+import { onBeforeMount, ref, watch, type Ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { refDebounced } from '@vueuse/core'
 
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
@@ -22,6 +23,7 @@ const router = useRouter()
 const loading = ref(true)
 const error: Ref<string | null> = ref(null)
 const search = ref('')
+const debouncedSearch = refDebounced(search, 300)
 const rows: Ref<IRecovery[]> = ref([])
 
 const columns = [
@@ -34,29 +36,12 @@ const columns = [
   { field: 'status', title: t('recovery.list.col.status'), width: '11rem' },
 ]
 
-const filteredRows = computed(() => {
-  const q = search.value.trim().toLowerCase()
-  if (!q) return rows.value
-  return rows.value.filter((r) => {
-    const docName = (r.documentName ?? '').toLowerCase()
-    const creator = (r.attribution?.creatorName ?? '').toLowerCase()
-    const reviewer = (r.attribution?.reviewerName ?? '').toLowerCase()
-    const typeLabel = recoveryDocumentTypeLabel(r.type).toLowerCase()
-    return (
-      String(r.id).includes(q) ||
-      docName.includes(q) ||
-      typeLabel.includes(q) ||
-      creator.includes(q) ||
-      reviewer.includes(q)
-    )
-  })
-})
-
-async function load() {
+async function load(query: string) {
   try {
     loading.value = true
     error.value = null
-    rows.value = await api.recovery.list({ limit: 200 })
+    const q = query.trim()
+    rows.value = q ? await api.recovery.list({ q }) : await api.recovery.list({ limit: 200 })
   } catch (e) {
     error.value = getErrorMessage(e) ?? t('error.generic')
   } finally {
@@ -64,7 +49,8 @@ async function load() {
   }
 }
 
-onBeforeMount(load)
+onBeforeMount(() => load(''))
+watch(debouncedSearch, (q) => load(q))
 
 function handleSelect(row: IRecovery) {
   router.push({ name: 'recovery-view', params: { id: row.id } })
@@ -94,7 +80,7 @@ function newRecovery() {
           :placeholder="t('recovery.list.searchPlaceholder')"
         />
       </div>
-      <span class="text-xs text-grey-700">{{ filteredRows.length }} / {{ rows.length }}</span>
+      <span class="text-xs text-grey-700">{{ rows.length }}</span>
     </div>
 
     <Alert v-if="error" :closeable="true" class="mb-3" @close="error = null">
@@ -102,7 +88,7 @@ function newRecovery() {
     </Alert>
 
     <Table
-      :rows="filteredRows"
+      :rows="rows"
       :columns="columns"
       :loading="loading"
       :emptyMessage="t('recovery.list.empty')"


### PR DESCRIPTION
## Summary
- Switches `InquiryListView` + `RecoveryListView` from client-side filtering of the last-200 cache to debounced (300ms) server-side `?q=` calls.
- Empty search box keeps the existing most-recent-200 browse; non-empty hits the API and gets matches across id, document_name, and sample address/BAG identifiers.
- Updated NL placeholder copy to reflect what's actually searchable now ("Zoek op id, naam, adres of BAG…").
- Drop the now-misleading `M / N` counter (M was the local filter, N was the cached window).

Pairs with FunderMapsApi#63 — the API there grows the `?q=` surface that this PR consumes.

## Test plan
- [ ] Empty search → recent 200 inquiries/recoveries load as before
- [ ] Type an inquiry id older than the 200 most-recent → row shows up
- [ ] Type a `gfm-` address fragment → matching inquiries appear
- [ ] Type a BAG NUMMERAANDUIDING fragment → matching inquiries appear
- [ ] Type a BAG PAND id → matching inquiries/recoveries appear
- [ ] Search box is debounced (no request per keystroke)
- [ ] `pnpm type-check` clean
- [ ] `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)