### PR TITLE
refactor(inquiry-step2): widen side panels, narrow the form column

### DIFF
--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -259,7 +259,7 @@ function previous() {
 
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[18rem_1fr_22rem]"
+      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">


### PR DESCRIPTION
## Summary
Follow-up to #246. The middle (form) column was too wide and the address / map columns too narrow at lg+. Bump address list 18rem → 26rem and map column 22rem → 32rem; switch the middle from `1fr` to `minmax(0,1fr)` so it shrinks for its neighbours instead of crowding them.

## Test plan
- [ ] Side panels are visibly wider
- [ ] Form column is narrower but still comfortable
- [ ] Address list rows don't truncate
- [ ] Map still sticky and renders correctly
- [ ] `pnpm type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)