### PR TITLE
fix(auth): logout menu was off-screen + recover from bad SSO callback

### DIFF
--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -73,10 +73,13 @@ function handleLogout() {
       <span class="hidden text-sm font-medium text-grey-800 sm:inline">{{ userName }}</span>
     </button>
 
+    <!-- Opens upward: this menu lives at the bottom of the fixed full-height
+         sidebar, so a downward dropdown would render below the viewport and the
+         logout/app-switcher items would be unclickable. -->
     <div
       v-if="open"
       role="menu"
-      class="absolute right-0 z-50 mt-2 w-56 rounded-lg border border-grey-200 bg-white py-2 shadow-card"
+      class="absolute bottom-full left-0 z-50 mb-2 w-56 rounded-lg border border-grey-200 bg-white py-2 shadow-card"
     >
       <p class="px-4 pb-1 text-xs font-semibold tracking-wide text-grey-700 uppercase">
         {{ t('userMenu.apps') }}

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -7,7 +7,9 @@
     "logout": "Uitloggen",
     "email": "E-mailadres",
     "password": "Wachtwoord",
-    "invalidCredentials": "Onjuiste e-mail of wachtwoord"
+    "invalidCredentials": "Onjuiste e-mail of wachtwoord",
+    "loginFailed": "Inloggen is niet gelukt. Mogelijk heeft het actieve account geen toegang tot deze app.",
+    "signInOtherAccount": "Inloggen met een ander account"
   },
   "nav": {
     "reports": "Rapportages",

--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 import Spinner from '@/components/Common/Spinner.vue'
-import { exchangeCode } from '@/services/oidc'
+import { exchangeCode, logoutRedirect } from '@/services/oidc'
 import { useSessionStore } from '@/stores/session'
 
 const { t } = useI18n()
@@ -12,13 +12,13 @@ const route = useRoute()
 const router = useRouter()
 const sessionStore = useSessionStore()
 
-const error = ref<string | null>(null)
+const failed = ref(false)
 
 onMounted(async () => {
   const code = route.query.code
   const state = route.query.state
   if (typeof code !== 'string') {
-    error.value = t('auth.invalidCredentials')
+    failed.value = true
     return
   }
   try {
@@ -26,17 +26,38 @@ onMounted(async () => {
     await sessionStore.authenticateFromAccessToken()
     router.replace({ name: 'inquiry-list' })
   } catch {
-    error.value = t('auth.invalidCredentials')
+    // A callback failure is NOT a credentials problem — the code was issued.
+    // It usually means the live SSO session belongs to an account that can't
+    // use this app (e.g. one signed in via maps.fundermaps.com). Don't mislabel
+    // it as "wrong password"; offer a working escape (signOut() below).
+    failed.value = true
   }
 })
+
+// End the SSO session at the provider, then land on /login for a fresh sign-in.
+// A plain link back to /login would silently re-authenticate via the still-alive
+// SSO session — i.e. straight back into the same wrong account and the same
+// error. RP-initiated logout breaks that loop. (See oidc.ts logoutRedirect.)
+function signOut() {
+  logoutRedirect()
+}
 </script>
 
 <template>
   <!-- Neutral loading while the code is exchanged — deliberately NOT the
        AuthWrapper login chrome, so the hand-off back from the auth app doesn't
        flash a login-page look before landing on the app. -->
-  <div class="grid min-h-screen place-content-center">
-    <p v-if="error" class="text-sm text-red-500">{{ error }}</p>
+  <div class="grid min-h-screen place-content-center px-6 text-center">
+    <template v-if="failed">
+      <p class="text-sm text-grey-700">{{ t('auth.loginFailed') }}</p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-500"
+        @click="signOut"
+      >
+        {{ t('auth.signInOtherAccount') }}
+      </button>
+    </template>
     <Spinner v-else />
   </div>
 </template>


### PR DESCRIPTION
Fixes #990.

## Report 1 — "Uitloggen uit app.fundermaps.com niet mogelijk in de UI"

Root cause is a layout bug, not auth. `UserMenu` lives at the bottom of the `fixed inset-y-0` full-height sidebar, but its dropdown opened **downward** (`mt-2`). On a 1280×720 viewport the logout item rendered at y≈807–844 — ~120px **below the fold and unclickable**. Verified with a headless-browser repro (bounding boxes + screenshots).

**Fix:** the dropdown opens **upward** (`bottom-full mb-2`, left-aligned so it doesn't clip the sidebar edge). After the fix the logout sits on-screen, and clicking it fires `/oauth2/end-session` and actually ends the SSO session — verified end-to-end in a real browser.

This also covers report 2's "kan niet wisselen van account": switching from a maps account to the app account requires logging out, which was unreachable.

## Report 2 — cross-account callback shows "Onjuiste e-mail of wachtwoord"

A callback failure is **not** a credentials problem — a code *was* issued. It typically means the live SSO session belongs to an account that can't use this app (e.g. one signed in via maps). So:
- stop mislabeling it as "wrong email/password" → neutral message
- the recovery button now does an RP logout (`logoutRedirect`) instead of a link back to `/login`, which would silently re-authenticate as the same wrong account and loop.

## Notes
- `enable_end_session=true` and `post_logout_redirect_uris` are already correct in prod; sign-out via the app's OIDC access token is a no-op on the SSO session (only the BA session credential revokes it), so `end-session` is the correct logout and works as-is.
- Type-checks clean. No backend/DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)