### PR TITLE
feat(view): allow admins to reopen approved reports (#250)

### DIFF
--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -45,7 +45,9 @@
       }
     },
     "view": {
-      "back": "Terug naar rapportages"
+      "back": "Terug naar rapportages",
+      "reopen": "Heropenen",
+      "reopenConfirm": "Goedgekeurd rapport heropenen voor correcties? De status keert terug naar 'In behandeling'."
     }
   },
   "recovery": {
@@ -65,7 +67,9 @@
       }
     },
     "view": {
-      "back": "Terug naar herstel"
+      "back": "Terug naar herstel",
+      "reopen": "Heropenen",
+      "reopenConfirm": "Goedgekeurd herstel-dossier heropenen voor correcties? De status keert terug naar 'In behandeling'."
     }
   }
 }

--- a/src/views/inquiry/InquiryView.vue
+++ b/src/views/inquiry/InquiryView.vue
@@ -54,6 +54,9 @@ const canSubmitForReview = computed(
     status.value === AUDIT_STATUS.REJECTED,
 )
 const isPendingReview = computed(() => status.value === AUDIT_STATUS.PENDING_REVIEW)
+// Escape hatch for "approved but an error surfaced later" — restricted to org
+// admins (issue #250). The API's /reset is an unconditional → pending move.
+const isReopenable = computed(() => status.value === AUDIT_STATUS.DONE)
 
 async function load() {
   try {
@@ -95,6 +98,17 @@ async function handleApprove() {
   try {
     actionError.value = null
     await api.inquiry.approve(inquiryId.value)
+    await load()
+  } catch (e) {
+    actionError.value = getErrorMessage(e) ?? t('error.generic')
+  }
+}
+
+async function handleReopen() {
+  if (!confirm(t('inquiry.view.reopenConfirm'))) return
+  try {
+    actionError.value = null
+    await api.inquiry.reset(inquiryId.value)
     await load()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? t('error.generic')
@@ -181,6 +195,12 @@ async function handleDelete() {
               danger
               label="Afkeuren"
               @click="showRejectModal = true"
+            />
+            <Button
+              v-if="isReopenable && isSuperUser"
+              outline
+              :label="t('inquiry.view.reopen')"
+              @click="handleReopen"
             />
             <Button v-if="isSuperUser" danger label="Verwijderen" @click="handleDelete" />
           </div>

--- a/src/views/recovery/RecoveryView.vue
+++ b/src/views/recovery/RecoveryView.vue
@@ -57,6 +57,9 @@ const canSubmitForReview = computed(
     status.value === AUDIT_STATUS.REJECTED,
 )
 const isPendingReview = computed(() => status.value === AUDIT_STATUS.PENDING_REVIEW)
+// Escape hatch for "approved but an error surfaced later" — restricted to org
+// admins (issue #250). The API's /reset is an unconditional → pending move.
+const isReopenable = computed(() => status.value === AUDIT_STATUS.DONE)
 
 async function load() {
   try {
@@ -98,6 +101,17 @@ async function handleApprove() {
   try {
     actionError.value = null
     await api.recovery.approve(recoveryId.value)
+    await load()
+  } catch (e) {
+    actionError.value = getErrorMessage(e) ?? t('error.generic')
+  }
+}
+
+async function handleReopen() {
+  if (!confirm(t('recovery.view.reopenConfirm'))) return
+  try {
+    actionError.value = null
+    await api.recovery.reset(recoveryId.value)
     await load()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? t('error.generic')
@@ -184,6 +198,12 @@ async function handleDelete() {
               danger
               label="Afkeuren"
               @click="showRejectModal = true"
+            />
+            <Button
+              v-if="isReopenable && isSuperUser"
+              outline
+              :label="t('recovery.view.reopen')"
+              @click="handleReopen"
             />
             <Button v-if="isSuperUser" danger label="Verwijderen" @click="handleDelete" />
           </div>


### PR DESCRIPTION
## Summary
- Adds a **Heropenen** button to `InquiryView` and `RecoveryView`, visible only when the report is `DONE` and the current user is a superuser.
- Wires it to the existing `POST /api/inquiry/:id/reset` / `POST /api/recovery/:id/reset` endpoint, which unconditionally moves the audit status back to `pending` so the report can be corrected, re-reviewed and re-approved.

Closes #250.

## Why this shape
- Backend was already capable — `assertCanWrite` + the unconditional `pending: []` transition in `transitionStatus`. The only missing piece was the UI hook for DONE reports.
- Gated to `isSuperUser` to match the issue's "in het adminpanel" framing — verifiers can already approve/reject, but undoing an approval after the fact is an admin escape hatch, not a routine review action.
- Placed before the destructive "Verwijderen" button so the destructive action stays last in the row.

## Test plan
- [x] `pnpm type-check` clean
- [x] Drove the full audit lifecycle against the local API end-to-end as admin: `pending → /status_review → /status_approved → DONE → /reset → pending` — every transition returned 204 and the badge round-tripped as expected.
- [ ] Smoke in dev: open a DONE inquiry as an org admin, click **Heropenen**, confirm status reverts to `In bewerking` and the **Bewerken** + **Aanbieden ter review** buttons reappear.
- [ ] Same for a DONE recovery dossier.
- [ ] Verify the button is hidden for non-DONE statuses and for non-admin roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)