### PR TITLE
fix(inquiry-step2): stop collapsing the form col at the lg breakpoint (#249)

### DIFF
--- a/src/components/Inquiry/SampleForm.vue
+++ b/src/components/Inquiry/SampleForm.vue
@@ -66,7 +66,7 @@ function onSave() {
 </script>
 
 <template>
-  <Card class="List col-span-3 lg:col-span-2">
+  <Card class="List">
     <header
       class="-mx-5 -mt-5 flex flex-wrap items-center justify-between gap-4 border-b border-grey-200 px-5 py-4"
     >

--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -257,9 +257,13 @@ function previous() {
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
+    <!-- 3-col layout at xl+ only. The two side cols (26rem + 32rem) plus the
+         MainWrapper padding total 1024px on their own, so at the lg
+         breakpoint the middle column would collapse to zero width and the
+         form would render letter-by-letter (issue #249). Below xl we stack. -->
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+      class="grid grid-cols-1 items-start gap-4 xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
@@ -293,8 +297,8 @@ function previous() {
         </p>
       </Card>
 
-      <!-- Form column (col 2 at lg+, last on mobile). -->
-      <div class="order-3 lg:order-2">
+      <!-- Form column (col 2 at xl+, last on smaller screens). -->
+      <div class="order-3 xl:order-2">
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
         </Card>
@@ -307,14 +311,14 @@ function previous() {
         />
       </div>
 
-      <!-- Map column (col 3 at lg+, thumbnail above the form on mobile).
-           Sticky on lg+ so the operator keeps a spatial reference while
-           scrolling the sample form. Plain bordered div, not <Card> —
+      <!-- Map column (col 3 at xl+, thumbnail above the form on smaller
+           screens). Sticky on xl+ so the operator keeps a spatial reference
+           while scrolling the sample form. Plain bordered div, not <Card> —
            Card's body has auto height and would collapse SampleMap's
            h-full to zero (see PR #244 for the original landmine). -->
-      <div class="order-2 lg:order-3 lg:sticky lg:top-4">
+      <div class="order-2 xl:order-3 xl:sticky xl:top-4">
         <div
-          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white lg:h-[calc(100vh-8rem)] lg:min-h-[480px]"
+          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
         >
           <SampleMap
             v-if="mapPins.length"


### PR DESCRIPTION
## Summary
- Raises the 3-col layout breakpoint from `lg` to `xl` so it only kicks in when there's actually enough room.
- Drops a stale `col-span-3 lg:col-span-2` from `SampleForm.vue` that referenced the pre-#246 2-col grid.

Closes #249.

## Root cause
The two fixed side columns plus the gaps and `MainWrapper`'s `p-8` total \`26rem + 32rem + 2×16px + 64px = 1024px\` — exactly the `lg` breakpoint. So at viewports between 1024 and 1280px the middle column had **zero width** and the sample form rendered letter-by-letter, with the BAG-ID clipping and the action buttons sliding off-screen. The issue's screenshot looked OK at the 1537×993 monitor metadata, but the actual repro hits anyone with a smaller browser window or a laptop docked at a midsized resolution.

Raising the threshold to \`xl\` (1280px) gives the middle column at minimum \`1280 − 64 − 416 − 512 − 32 = 256px\`, growing past 512px at 2xl. Below xl the cards stack at full content width — which is what the issue reporter actually asked for.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm build\` clean
- [ ] Visual: open an inquiry's Step 2 at viewport widths around 800px, 1100px, 1300px and 1600px — confirm the layout stacks below xl, fans into 3 cols at xl, and the sample form header (address + buttons) wraps cleanly at every size
- [ ] Confirm the map column still sticks to the viewport on xl+ while scrolling the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)