### PR TITLE
refactor(recovery-step2): mirror InquiryStep2's spatial-context layout

### DIFF
--- a/src/views/recovery/RecoveryStep2.vue
+++ b/src/views/recovery/RecoveryStep2.vue
@@ -11,6 +11,7 @@ import AddressPicker from '@/components/Inquiry/AddressPicker.vue'
 import SampleForm from '@/components/Recovery/SampleForm.vue'
 import Spinner from '@/components/Common/Spinner.vue'
 import WizardSteps from '@/components/Common/WizardSteps.vue'
+import SampleMap, { type SamplePin } from '@/components/Mapbox/SampleMap.vue'
 import { RouterLink } from 'vue-router'
 
 import api from '@/services/fundermaps'
@@ -38,6 +39,26 @@ const actionError: Ref<string | null> = ref(null)
 
 const selectedId = ref<number | null>(null)
 const selected = computed(() => samples.value.find((s) => s.id === selectedId.value) ?? null)
+
+// Map markers — one per sample whose building has resolved coordinates.
+// Recovery samples key on the BAG PAND id; the geocoder /address/:id route
+// accepts that and returns the building's centroid lat/lng, so the pin
+// derivation mirrors the inquiry side. Samples whose building lacks a geom
+// just don't render a pin (the list + form still work).
+const mapPins = computed<SamplePin[]>(() => {
+  const out: SamplePin[] = []
+  for (const s of samples.value) {
+    const a = addressStore.cache[s.building]
+    if (a && a.latitude != null && a.longitude != null) {
+      out.push({ id: s.id, lat: a.latitude, lng: a.longitude })
+    }
+  }
+  return out
+})
+
+function handleMapSelect(id: string | number): void {
+  if (typeof id === 'number') selectSample(id)
+}
 
 async function load() {
   try {
@@ -191,8 +212,13 @@ function previous() {
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
-    <div v-else class="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      <Card class="lg:col-span-1 !p-0">
+    <!-- 3-col layout at xl+ only — see InquiryStep2 / issue #249. Below xl
+         the cards stack at full content width so the form isn't squeezed. -->
+    <div
+      v-else
+      class="grid grid-cols-1 items-start gap-4 xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+    >
+      <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
           <h3 class="text-sm font-semibold text-grey-800">Adressen ({{ samples.length }})</h3>
           <p class="mt-0.5 text-xs text-grey-700">
@@ -224,7 +250,8 @@ function previous() {
         </p>
       </Card>
 
-      <div class="lg:col-span-2">
+      <!-- Form column (col 2 at xl+, last on smaller screens). -->
+      <div class="order-3 xl:order-2">
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
         </Card>
@@ -235,6 +262,27 @@ function previous() {
           @save="handleSave"
           @delete="handleDelete"
         />
+      </div>
+
+      <!-- Map column (col 3 at xl+, thumbnail above the form on smaller
+           screens). Plain bordered div, not <Card> — see PR #244. -->
+      <div class="order-2 xl:order-3 xl:sticky xl:top-4">
+        <div
+          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
+        >
+          <SampleMap
+            v-if="mapPins.length"
+            :pins="mapPins"
+            :selected-id="selectedId"
+            @select="handleMapSelect"
+          />
+          <div
+            v-else
+            class="flex h-full items-center justify-center px-4 text-center text-xs text-grey-700"
+          >
+            Voeg een adres toe om de locatie op de kaart te zien.
+          </div>
+        </div>
       </div>
     </div>
   </MainWrapper>


### PR DESCRIPTION
## Summary
Brings `RecoveryStep2` in line with the spatial-context layout shipped on `InquiryStep2` in #246 / #247 / #249.

- 3-col grid at `xl+` (addresses list / form / map), stacks below `xl` so the form isn't squeezed at midsized viewports.
- Map column with the same sticky positioning + explicit height so Mapbox renders against a real container (not the zero-height landmine from #244).
- Pin click syncs the selected sample → focuses the matching row in the addresses list and the sample form.

## Note on PAND keying
Recovery samples store a BAG **PAND** id (not a gfm- address id). The geocoder's \`/api/geocoder/address/:id\` route already handles PAND input and returns a representative address with the building centroid, so pin derivation is the same shape as inquiry. Samples whose building lacks geometry simply don't render a pin — same behavior as on the inquiry side.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm build\` clean
- [x] Verified end-to-end against local API: PAND \`NL.IMBAG.PAND.…\` resolves through \`/api/geocoder/address/:id\` and returns a usable address row (centroid happens to be null on the sanitized dev DB; prod has the geom)
- [ ] Smoke in dev: open a recovery, navigate to Step 2, add a couple of samples — confirm pins render, clicking a pin focuses the row + form, and the layout stacks cleanly below xl

🤖 Generated with [Claude Code](https://claude.com/claude-code)