### PR TITLE
refactor(step2): hide the map below xl instead of stacking it

### DIFF
--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -257,13 +257,13 @@ function previous() {
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
-    <!-- 3-col layout at xl+ only. The two side cols (26rem + 32rem) plus the
-         MainWrapper padding total 1024px on their own, so at the lg
-         breakpoint the middle column would collapse to zero width and the
-         form would render letter-by-letter (issue #249). Below xl we stack. -->
+    <!-- Layout: stacked on mobile, addresses+form at lg, addresses+form+map
+         at xl. The map is an optional spatial-context aid — when there's
+         no room for a real 3-col layout we drop it entirely rather than
+         squeezing it under the form or shrinking the side cols. -->
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
@@ -297,8 +297,7 @@ function previous() {
         </p>
       </Card>
 
-      <!-- Form column (col 2 at xl+, last on smaller screens). -->
-      <div class="order-3 xl:order-2">
+      <div>
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
         </Card>
@@ -311,14 +310,13 @@ function previous() {
         />
       </div>
 
-      <!-- Map column (col 3 at xl+, thumbnail above the form on smaller
-           screens). Sticky on xl+ so the operator keeps a spatial reference
-           while scrolling the sample form. Plain bordered div, not <Card> —
-           Card's body has auto height and would collapse SampleMap's
-           h-full to zero (see PR #244 for the original landmine). -->
-      <div class="order-2 xl:order-3 xl:sticky xl:top-4">
+      <!-- Map column (xl+ only). Sticky so the operator keeps a spatial
+           reference while scrolling the sample form. Plain bordered div,
+           not <Card> — Card's body has auto height and would collapse
+           SampleMap's h-full to zero (#244). -->
+      <div class="hidden xl:sticky xl:top-4 xl:block">
         <div
-          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
+          class="overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
         >
           <SampleMap
             v-if="mapPins.length"

--- a/src/views/recovery/RecoveryStep2.vue
+++ b/src/views/recovery/RecoveryStep2.vue
@@ -212,11 +212,13 @@ function previous() {
       <span v-if="false">{{ t('common.loading') }}</span>
     </Card>
 
-    <!-- 3-col layout at xl+ only — see InquiryStep2 / issue #249. Below xl
-         the cards stack at full content width so the form isn't squeezed. -->
+    <!-- Layout: stacked on mobile, addresses+form at lg, addresses+form+map
+         at xl. The map is an optional spatial-context aid — when there's
+         no room for a real 3-col layout we drop it entirely rather than
+         squeezing it under the form or shrinking the side cols. -->
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
@@ -250,8 +252,7 @@ function previous() {
         </p>
       </Card>
 
-      <!-- Form column (col 2 at xl+, last on smaller screens). -->
-      <div class="order-3 xl:order-2">
+      <div>
         <Card v-if="!selected" class="flex items-center justify-center py-12">
           <p class="text-sm text-grey-700">Selecteer een adres om te bewerken.</p>
         </Card>
@@ -264,11 +265,10 @@ function previous() {
         />
       </div>
 
-      <!-- Map column (col 3 at xl+, thumbnail above the form on smaller
-           screens). Plain bordered div, not <Card> — see PR #244. -->
-      <div class="order-2 xl:order-3 xl:sticky xl:top-4">
+      <!-- Map column (xl+ only). Plain bordered div, not <Card> — see #244. -->
+      <div class="hidden xl:sticky xl:top-4 xl:block">
         <div
-          class="h-64 overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
+          class="overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
         >
           <SampleMap
             v-if="mapPins.length"


### PR DESCRIPTION
## Summary
Per feedback after #253: the map is an **optional** spatial-context aid, not load-bearing for the sample workflow. When the viewport doesn't have room for a real 3-col layout it's better to drop the map entirely than to either squeeze it under the form (extra scroll, dead space) or shrink the side cols.

Touches both InquiryStep2 and RecoveryStep2 — same shape, same fix.

## New behavior

| viewport | layout |
| --- | --- |
| \`< lg\` (≲ 1024px) | stacked: addresses → form |
| \`lg → xl\` (1024–1280px) | 2-col: addresses (26rem) + form (1fr), map hidden |
| \`xl+\` (≥ 1280px) | 3-col: addresses + form + sticky map (unchanged) |

## Drops
- The \`order-2 xl:order-3\` / \`order-3 xl:order-2\` flex-ordering tricks — no longer needed since the form always follows the addresses card.
- The \`h-64\` mobile thumbnail on the map div — the map never shows on small screens now.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm build\` clean
- [ ] Visual at 700 / 1100 / 1400px viewport widths: stack / 2-col-no-map / 3-col-with-map respectively
- [ ] Same for Recovery Step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)