### PR TITLE
refactor(step2): raise the map's breakpoint from xl to 2xl

### DIFF
--- a/src/views/inquiry/InquiryStep2.vue
+++ b/src/views/inquiry/InquiryStep2.vue
@@ -258,12 +258,12 @@ function previous() {
     </Card>
 
     <!-- Layout: stacked on mobile, addresses+form at lg, addresses+form+map
-         at xl. The map is an optional spatial-context aid — when there's
-         no room for a real 3-col layout we drop it entirely rather than
-         squeezing it under the form or shrinking the side cols. -->
+         at 2xl. The map is an optional spatial-context aid — show it only
+         when there's room for the middle col to stay comfortable (~512px
+         at the 2xl breakpoint, vs ~256px if we ran 3-col already at xl). -->
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] 2xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
@@ -310,13 +310,13 @@ function previous() {
         />
       </div>
 
-      <!-- Map column (xl+ only). Sticky so the operator keeps a spatial
+      <!-- Map column (2xl+ only). Sticky so the operator keeps a spatial
            reference while scrolling the sample form. Plain bordered div,
            not <Card> — Card's body has auto height and would collapse
            SampleMap's h-full to zero (#244). -->
-      <div class="hidden xl:sticky xl:top-4 xl:block">
+      <div class="hidden 2xl:sticky 2xl:top-4 2xl:block">
         <div
-          class="overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
+          class="overflow-hidden rounded-md border border-grey-200 bg-white 2xl:h-[calc(100vh-8rem)] 2xl:min-h-[480px]"
         >
           <SampleMap
             v-if="mapPins.length"

--- a/src/views/recovery/RecoveryStep2.vue
+++ b/src/views/recovery/RecoveryStep2.vue
@@ -213,12 +213,12 @@ function previous() {
     </Card>
 
     <!-- Layout: stacked on mobile, addresses+form at lg, addresses+form+map
-         at xl. The map is an optional spatial-context aid — when there's
-         no room for a real 3-col layout we drop it entirely rather than
-         squeezing it under the form or shrinking the side cols. -->
+         at 2xl. The map is an optional spatial-context aid — show it only
+         when there's room for the middle col to stay comfortable (~512px
+         at the 2xl breakpoint, vs ~256px if we ran 3-col already at xl). -->
     <div
       v-else
-      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
+      class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[26rem_minmax(0,1fr)] 2xl:grid-cols-[26rem_minmax(0,1fr)_32rem]"
     >
       <Card class="!p-0">
         <header class="border-b border-grey-200 px-4 py-3">
@@ -265,10 +265,10 @@ function previous() {
         />
       </div>
 
-      <!-- Map column (xl+ only). Plain bordered div, not <Card> — see #244. -->
-      <div class="hidden xl:sticky xl:top-4 xl:block">
+      <!-- Map column (2xl+ only). Plain bordered div, not <Card> — see #244. -->
+      <div class="hidden 2xl:sticky 2xl:top-4 2xl:block">
         <div
-          class="overflow-hidden rounded-md border border-grey-200 bg-white xl:h-[calc(100vh-8rem)] xl:min-h-[480px]"
+          class="overflow-hidden rounded-md border border-grey-200 bg-white 2xl:h-[calc(100vh-8rem)] 2xl:min-h-[480px]"
         >
           <SampleMap
             v-if="mapPins.length"


### PR DESCRIPTION
## Summary
Pushes the 3-col layout (and the map column) from \`xl\` (1280px) to \`2xl\` (1536px) on both InquiryStep2 and RecoveryStep2.

## Why
At \`xl\` the middle col only gets \`1280 − 64 − 416 − 512 − 32 = 256px\` — workable but still tight for the form's \`md:grid-cols-2\` layout. \`2xl\` gives it ~512px instead, which is the size the layout was actually designed for. Below 2xl we stay 2-col (addresses + form); below \`lg\` we stack. The map content itself is unchanged.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm build\` clean
- [ ] Visual at 1100 / 1400 / 1600px viewport widths: stack-or-2col / 2-col / 3-col-with-map respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)